### PR TITLE
Fix mobile scroll-to-section by adding missing IDs and handling content-visibility

### DIFF
--- a/apps/landing-page/src/layouts/main.astro
+++ b/apps/landing-page/src/layouts/main.astro
@@ -172,19 +172,33 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site).toString();
 				try {
 					const target = document.querySelector(hash);
 					if (target) {
+						// Reveal content-visibility:auto elements for accurate scroll positions
+						const deferred = document.querySelectorAll<HTMLElement>('.mobile-card--deferred');
+						for (const el of deferred) {
+							el.style.contentVisibility = 'visible';
+						}
+
 						// Force layout recalculation
 						document.body.offsetHeight;
 
 						const targetY = getOffsetTop(target);
-						console.log('[scroll] Found target, scrolling to:', hash, 'targetY:', targetY);
-						window.scrollTo(0, targetY);
-						console.log('[scroll] After scrollTo, current scrollY:', window.scrollY);
+						// Account for fixed navbar (5rem = 80px) and optional banner
+						const style = getComputedStyle(document.documentElement);
+						const bannerPx = parseFloat(style.getPropertyValue('--banner-height')) || 0;
+						const offset = 80 + bannerPx;
+
+						window.scrollTo(0, Math.max(0, targetY - offset));
+
+						// Restore content-visibility after layout settles
+						setTimeout(() => {
+							for (const el of deferred) {
+								el.style.contentVisibility = '';
+							}
+						}, 100);
 						return true;
-					} else {
-						console.log('[scroll] Target not found:', hash);
 					}
 				} catch (e) {
-					console.log('[scroll] Error:', e);
+					// Silently handle errors
 				}
 				return false;
 			}
@@ -197,13 +211,11 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site).toString();
 				const e = event as any;
 				const url = new URL(e.to);
 				pendingHash = url.hash || null;
-				console.log('[scroll] astro:before-preparation, hash:', pendingHash);
 			});
 
 			// After DOM swap but before animation, scroll to target
 			document.addEventListener('astro:after-swap', () => {
 				const hash = pendingHash || window.location.hash;
-				console.log('[scroll] astro:after-swap, hash:', hash);
 
 				if (hash) {
 					// Use requestAnimationFrame to ensure layout is computed
@@ -215,7 +227,6 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site).toString();
 
 			// Clear pending hash after page load
 			document.addEventListener('astro:page-load', () => {
-				console.log('[scroll] astro:page-load');
 				pendingHash = null;
 			});
 		</script>

--- a/apps/landing-page/src/pages/index.astro
+++ b/apps/landing-page/src/pages/index.astro
@@ -54,7 +54,7 @@ import { heroGrainGradient } from '../lib/shader-configs';
 
       <!-- Layer 3: Content cards (z-20) - scroll over the locked image -->
       <div class="relative z-20 px-4 pt-4 pb-4 gpu-layer">
-        <div class="relative rounded-lg overflow-hidden bg-[var(--pyre-black)] text-[var(--pyre-creme)] card-cta-animated my-8 mobile-card">
+        <div id="about" class="relative rounded-lg overflow-hidden bg-[var(--pyre-black)] text-[var(--pyre-creme)] card-cta-animated my-8 mobile-card">
           <AboutSection />
         </div>
         <div class="relative rounded-lg overflow-hidden bg-[var(--pyre-black)] text-[var(--pyre-creme)] my-8 mobile-card mobile-card--deferred">
@@ -74,7 +74,7 @@ import { heroGrainGradient } from '../lib/shader-configs';
         </div>
         <SectionBridge bgColor="var(--pyre-black)" variant="wave" position="bottom" height='sm'/>
         <SectionBridge bgColor="var(--pyre-black)" variant="wave" position="top" height='sm' />
-        <div class="relative rounded-b-lg overflow-hidden bg-[var(--pyre-black)] text-[var(--pyre-creme)] mb-8 mobile-card mobile-card--deferred">
+        <div id="membership" class="relative rounded-b-lg overflow-hidden bg-[var(--pyre-black)] text-[var(--pyre-creme)] mb-8 mobile-card mobile-card--deferred">
           <MembershipSection />
         </div>
         <div class="relative rounded-lg overflow-hidden bg-[var(--pyre-black)] text-[var(--pyre-creme)] card-cta-animated my-8 mobile-card mobile-card--deferred">
@@ -178,6 +178,39 @@ import { heroGrainGradient } from '../lib/shader-configs';
   function initSmoothScroll() {
     const lgBreakpoint = 1024;
 
+    /**
+     * On mobile, content-visibility:auto defers rendering of off-screen cards,
+     * so scrollIntoView computes positions from estimated placeholder sizes.
+     * Temporarily force all deferred cards to render before scrolling so
+     * the browser calculates the correct scroll offset.
+     */
+    function revealDeferredCards(): (() => void) | null {
+      if (window.innerWidth >= lgBreakpoint) return null;
+
+      const deferred = document.querySelectorAll<HTMLElement>('.mobile-card--deferred');
+      if (deferred.length === 0) return null;
+
+      for (const el of deferred) {
+        el.style.contentVisibility = 'visible';
+      }
+      // Force synchronous layout so scroll position is accurate
+      document.body.offsetHeight;
+
+      return () => {
+        for (const el of deferred) {
+          el.style.contentVisibility = '';
+        }
+      };
+    }
+
+    function findTarget(sectionId: string): Element | null {
+      if (window.innerWidth >= lgBreakpoint) {
+        const el = document.querySelector(`[data-section="${sectionId}"]`);
+        if (el) return el;
+      }
+      return document.getElementById(sectionId);
+    }
+
     document.addEventListener('click', (e) => {
       const target = e.target as HTMLElement;
       // Match any anchor with a hash in the href (handles /#about, /pyre/#about, #about)
@@ -196,51 +229,34 @@ import { heroGrainGradient } from '../lib/shader-configs';
       if (hash === '#') return;
 
       const sectionId = hash.slice(1); // Remove the #
-      const isDesktop = window.innerWidth >= lgBreakpoint;
-
-      let targetElement: Element | null = null;
-
-      if (isDesktop) {
-        // On desktop, find element with data-section attribute
-        targetElement = document.querySelector(`[data-section="${sectionId}"]`);
-      }
-
-      // Fall back to ID if data-section not found or on mobile
-      if (!targetElement) {
-        targetElement = document.getElementById(sectionId);
-      }
+      const targetElement = findTarget(sectionId);
 
       if (targetElement) {
         e.preventDefault();
+        const restore = revealDeferredCards();
         targetElement.scrollIntoView({ behavior: 'smooth' });
         // Update URL hash without jumping
         history.pushState(null, '', hash);
+        // Restore content-visibility after smooth scroll finishes
+        if (restore) setTimeout(restore, 1000);
       }
     });
 
-    // Handle direct URL navigation with hash
+    // Handle direct URL navigation with hash (initial load or back/forward)
     function scrollToHashTarget() {
       const hash = window.location.hash;
       if (!hash) return;
 
       const sectionId = hash.slice(1);
-      const isDesktop = window.innerWidth >= lgBreakpoint;
-
-      let targetElement: Element | null = null;
-
-      if (isDesktop) {
-        targetElement = document.querySelector(`[data-section="${sectionId}"]`);
-      }
-
-      if (!targetElement) {
-        targetElement = document.getElementById(sectionId);
-      }
+      const targetElement = findTarget(sectionId);
 
       if (targetElement) {
-        // Small delay to ensure layout is complete
-        setTimeout(() => {
-          targetElement!.scrollIntoView({ behavior: 'smooth' });
-        }, 100);
+        const restore = revealDeferredCards();
+        // Wait for layout to stabilize after forcing visibility
+        requestAnimationFrame(() => {
+          targetElement.scrollIntoView({ behavior: 'smooth' });
+          if (restore) setTimeout(restore, 1000);
+        });
       }
     }
 


### PR DESCRIPTION
Mobile anchor navigation was broken due to three issues:
- Missing id="about" and id="membership" on mobile card wrappers (desktop
  uses data-section attributes, but mobile falls back to getElementById)
- content-visibility:auto on deferred cards caused scrollIntoView to compute
  positions from 500px placeholder sizes instead of actual rendered heights
- Hash-on-load used an insufficient 100ms timeout instead of waiting for layout

The fix reveals all deferred cards before scrolling so the browser calculates
correct offsets, then restores content-visibility after scroll completes. Also
updates the view-transition scroll handler to account for navbar offset and
removes debug console.log statements.

https://claude.ai/code/session_01KXRp3VEJcGPa1FYjFt3a67