### PR TITLE
Add LLM-friendly endpoints and structured data for AI agent indexing

### DIFF
--- a/apps/landing-page/astro.config.mjs
+++ b/apps/landing-page/astro.config.mjs
@@ -29,7 +29,13 @@ export default defineConfig({
     plugins: [tailwindcss()],
   },
 
-  integrations: [mdx(), react(), sitemap()],
+  integrations: [
+    mdx(),
+    react(),
+    sitemap({
+      filter: (page) => !page.includes('/api/') && !page.includes('/account/'),
+    }),
+  ],
 
   output: 'server', // Server mode: pages SSR by default, use `export const prerender = true` for static pages
   adapter: vercel({

--- a/apps/landing-page/src/layouts/main.astro
+++ b/apps/landing-page/src/layouts/main.astro
@@ -10,8 +10,8 @@ import warmSaunaImg from '../assets/images/warm_sauna.webp';
 import faviconSvg from '../assets/logos/pyre_logo.svg?raw';
 import AnnouncementBanner from '../components/AnnouncementBanner.astro';
 import Footer from '../components/Footer.astro';
-import PromoPopup from '../components/PromoPopup.astro';
 import Navbar from '../components/Navbar.astro';
+import PromoPopup from '../components/PromoPopup.astro';
 import PostHog from '../components/posthog.astro';
 import {
   SOCIAL_IMAGE,
@@ -63,6 +63,50 @@ const absoluteSocialImage = Astro.site
 
 // Generate canonical URL
 const canonicalURL = new URL(Astro.url.pathname, Astro.site).toString();
+
+// LLMs.txt URL for AI agent discovery
+const llmsTxtUrl = Astro.site ? new URL('/llms.txt', Astro.site).toString() : '/llms.txt';
+
+// Organization structured data for homepage
+const organizationJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'HealthAndBeautyBusiness',
+  name: 'Pyre Sauna + Cold Plunge',
+  description:
+    'A modern communal bathhouse in Richmond, VA offering traditional Finnish saunas, cold plunge pools, and guided wellness experiences.',
+  url: Astro.site?.toString() ?? 'https://pyresauna.com',
+  email: 'hi@pyresauna.com',
+  image: absoluteSocialImage,
+  sameAs: ['https://instagram.com/pyre_sauna'],
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Richmond',
+    addressRegion: 'VA',
+    addressCountry: 'US',
+  },
+  hasOfferCatalog: {
+    '@type': 'OfferCatalog',
+    name: 'Memberships',
+    itemListElement: [
+      {
+        '@type': 'Offer',
+        name: 'Limited Membership',
+        description: '4 sauna and cold plunge sessions per month',
+        price: '99',
+        priceCurrency: 'USD',
+        eligibleDuration: { '@type': 'QuantitativeValue', value: 1, unitCode: 'MON' },
+      },
+      {
+        '@type': 'Offer',
+        name: 'Unlimited Membership',
+        description: 'Unlimited sauna and cold plunge access',
+        price: '199',
+        priceCurrency: 'USD',
+        eligibleDuration: { '@type': 'QuantitativeValue', value: 1, unitCode: 'MON' },
+      },
+    ],
+  },
+};
 ---
 
 <html lang="en" style={`--asset-base: ${base};`}> 
@@ -76,6 +120,9 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site).toString();
 		
 		<!-- Canonical URL -->
 		<link rel="canonical" href={canonicalURL} />
+
+		<!-- LLMs.txt discovery for AI agents -->
+		<link rel="alternate" type="text/markdown" href={llmsTxtUrl} title="LLM-friendly site content" />
 		
 		<!-- Open Graph / Facebook -->
 		<meta property="og:type" content={ogType} />
@@ -133,6 +180,9 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site).toString();
 				},
 				keywords: article.tags?.join(', '),
 			})} />
+		)}
+		{isHomePage && (
+			<script type="application/ld+json" set:html={JSON.stringify(organizationJsonLd)} />
 		)}
 		<link rel="preload" as="font" href={fontRegularWoff2} type="font/woff2" crossorigin />
 		<link rel="preload" as="font" href={fontSemiBoldWoff2} type="font/woff2" crossorigin />

--- a/apps/landing-page/src/layouts/main.astro
+++ b/apps/landing-page/src/layouts/main.astro
@@ -13,11 +13,16 @@ import Footer from '../components/Footer.astro';
 import PromoPopup from '../components/PromoPopup.astro';
 import Navbar from '../components/Navbar.astro';
 import PostHog from '../components/posthog.astro';
+import faqs from '../lib/faqs';
 import {
+  ORGANIZATION,
+  SITE_LOCALE,
+  SITE_NAME,
   SOCIAL_IMAGE,
   SOCIAL_IMAGE_ALT,
   SOCIAL_IMAGE_HEIGHT,
   SOCIAL_IMAGE_WIDTH,
+  TWITTER_HANDLE,
 } from '../lib/seo';
 
 // Generate optimized image URLs for preloading
@@ -82,6 +87,8 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site).toString();
     <meta property="og:url" content={canonicalURL} />
 		<meta property="og:title" content={title} />
 		<meta property="og:description" content={description} />
+		<meta property="og:site_name" content={SITE_NAME} />
+		<meta property="og:locale" content={SITE_LOCALE} />
     <meta property="og:image" content={absoluteSocialImage} />
     <meta property="og:image:width" content={String(SOCIAL_IMAGE_WIDTH)} />
     <meta property="og:image:height" content={String(SOCIAL_IMAGE_HEIGHT)} />
@@ -99,14 +106,27 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site).toString();
 		)}
 		
 		<!-- Twitter -->
-		<meta property="twitter:card" content="summary_large_image" />
-    <meta property="twitter:url" content={canonicalURL} />
-		<meta property="twitter:title" content={title} />
-		<meta property="twitter:description" content={description} />
-    <meta property="twitter:image" content={absoluteSocialImage} />
-    <meta property="twitter:image:alt" content={ogImage ? title : SOCIAL_IMAGE_ALT} />
+		<meta name="twitter:card" content="summary_large_image" />
+		<meta name="twitter:site" content={TWITTER_HANDLE} />
+		<meta name="twitter:url" content={canonicalURL} />
+		<meta name="twitter:title" content={title} />
+		<meta name="twitter:description" content={description} />
+		<meta name="twitter:image" content={absoluteSocialImage} />
+		<meta name="twitter:image:alt" content={ogImage ? title : SOCIAL_IMAGE_ALT} />
+
+		<!-- Indexing directives: allow large snippets and image previews -->
+		<meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
 		
-		<!-- JSON-LD Structured Data for Articles -->
+		<!-- JSON-LD: WebSite schema (all pages — enables sitelinks search box) -->
+		<script type="application/ld+json" set:html={JSON.stringify({
+			'@context': 'https://schema.org',
+			'@type': 'WebSite',
+			name: SITE_NAME,
+			url: Astro.site?.toString() ?? 'https://pyresauna.com',
+			publisher: ORGANIZATION,
+		})} />
+
+		<!-- JSON-LD: Article schema (blog posts only) -->
 		{ogType === 'article' && article && (
 			<script type="application/ld+json" set:html={JSON.stringify({
 				'@context': 'https://schema.org',
@@ -120,8 +140,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site).toString();
 					name: article.author,
 				},
 				publisher: {
-					'@type': 'Organization',
-					name: 'Pyre',
+					...ORGANIZATION,
 					logo: {
 						'@type': 'ImageObject',
 						url: Astro.site ? new URL('/logos/gray/logo.png', Astro.site).toString() : '/logos/gray/logo.png',
@@ -132,6 +151,82 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site).toString();
 					'@id': canonicalURL,
 				},
 				keywords: article.tags?.join(', '),
+			})} />
+		)}
+
+		<!-- JSON-LD: LocalBusiness schema (homepage only — triggers rich results) -->
+		{isHomePage && (
+			<script type="application/ld+json" set:html={JSON.stringify({
+				'@context': 'https://schema.org',
+				'@type': 'HealthAndBeautyBusiness',
+				'@id': (Astro.site?.toString() ?? 'https://pyresauna.com') + '/#organization',
+				name: 'Pyre Sauna + Cold Plunge',
+				description: description,
+				url: Astro.site?.toString() ?? 'https://pyresauna.com',
+				email: 'hi@pyresauna.com',
+				image: absoluteSocialImage,
+				priceRange: '$$',
+				address: {
+					'@type': 'PostalAddress',
+					addressLocality: 'Richmond',
+					addressRegion: 'VA',
+					addressCountry: 'US',
+				},
+				sameAs: ['https://instagram.com/pyre_sauna'],
+				hasOfferCatalog: {
+					'@type': 'OfferCatalog',
+					name: 'Sauna & Wellness Services',
+					itemListElement: [
+						{
+							'@type': 'Offer',
+							itemOffered: {
+								'@type': 'Service',
+								name: 'Single Session',
+								description: 'Drop-in sauna and cold plunge visit',
+							},
+						},
+						{
+							'@type': 'Offer',
+							itemOffered: {
+								'@type': 'Service',
+								name: '2-Pack Intro',
+								description: '2 sessions for new guests',
+							},
+						},
+						{
+							'@type': 'Offer',
+							itemOffered: {
+								'@type': 'Service',
+								name: 'Limited Membership',
+								description: '4 sauna and cold plunge sessions per month',
+							},
+						},
+						{
+							'@type': 'Offer',
+							itemOffered: {
+								'@type': 'Service',
+								name: 'Unlimited Membership',
+								description: 'Unlimited sauna and cold plunge access',
+							},
+						},
+					],
+				},
+			})} />
+		)}
+
+		<!-- JSON-LD: FAQPage schema (homepage only — triggers FAQ rich results) -->
+		{isHomePage && (
+			<script type="application/ld+json" set:html={JSON.stringify({
+				'@context': 'https://schema.org',
+				'@type': 'FAQPage',
+				mainEntity: faqs.items.map((faq) => ({
+					'@type': 'Question',
+					name: faq.question,
+					acceptedAnswer: {
+						'@type': 'Answer',
+						text: faq.answer,
+					},
+				})),
 			})} />
 		)}
 		<link rel="preload" as="font" href={fontRegularWoff2} type="font/woff2" crossorigin />

--- a/apps/landing-page/src/lib/seo.ts
+++ b/apps/landing-page/src/lib/seo.ts
@@ -4,3 +4,17 @@ export const SOCIAL_IMAGE = socialImage;
 export const SOCIAL_IMAGE_ALT = 'Pyre Sauna + Cold Plunge';
 export const SOCIAL_IMAGE_WIDTH = 1920;
 export const SOCIAL_IMAGE_HEIGHT = 1293;
+
+// Organization / site-level SEO constants
+export const SITE_NAME = 'Pyre Sauna + Cold Plunge';
+export const SITE_LOCALE = 'en_US';
+export const TWITTER_HANDLE = '@pyre_sauna';
+
+// Organization structured data (reused across JSON-LD schemas)
+export const ORGANIZATION = {
+	'@type': 'Organization' as const,
+	name: 'Pyre Sauna + Cold Plunge',
+	url: 'https://pyresauna.com',
+	email: 'hi@pyresauna.com',
+	sameAs: ['https://instagram.com/pyre_sauna'],
+};

--- a/apps/landing-page/src/pages/events/index.astro
+++ b/apps/landing-page/src/pages/events/index.astro
@@ -10,7 +10,7 @@ import fallbackEvents from '@/lib/events';
 // SEO metadata
 const title = 'Events - Pyre';
 const description =
-  '';
+  'Browse and book upcoming sauna sessions, cold plunge classes, and guided wellness events at Pyre in Richmond, VA.';
 ---
 
 <MainLayout title={title} description={description} transparentNav={true}>

--- a/apps/landing-page/src/pages/index.astro
+++ b/apps/landing-page/src/pages/index.astro
@@ -21,7 +21,7 @@ import { heroGrainGradient } from '../lib/shader-configs';
 ---
 
 <Layout isHomePage={true}>
-  <main class="dark">
+  <div class="dark">
     <!-- Mobile: three-layer scroll effect -->
     <!-- Black background prevents white showing during overscroll bounce -->
     <div class="lg:hidden bg-[var(--pyre-black)]">
@@ -142,7 +142,7 @@ import { heroGrainGradient } from '../lib/shader-configs';
         </div>
       </div>
     </div>
-  </main>
+  </div>
 </Layout>
 
 <style>

--- a/apps/landing-page/src/pages/llms-full.txt.ts
+++ b/apps/landing-page/src/pages/llms-full.txt.ts
@@ -1,0 +1,134 @@
+import { getCollection } from 'astro:content';
+import type { APIRoute } from 'astro';
+import about from '@/lib/about';
+import benefits from '@/lib/experiences';
+import faqs from '@/lib/faqs';
+import groupBooking from '@/lib/group-booking';
+import membership from '@/lib/membership';
+
+export const prerender = true;
+
+export const GET: APIRoute = async ({ site }) => {
+  const baseUrl = site?.origin ?? 'https://pyresauna.com';
+
+  // Fetch all published blog posts
+  const allPosts = await getCollection('blog', ({ data }) => !data.draft);
+  const sortedPosts = allPosts.sort(
+    (a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime()
+  );
+
+  const blogSection = sortedPosts
+    .map(
+      (post) =>
+        `### ${post.data.title}\n\n- **URL**: ${baseUrl}/blog/${post.slug}\n- **Author**: ${post.data.author}\n- **Date**: ${post.data.date.toISOString().split('T')[0]}\n- **Tags**: ${post.data.tags.join(', ')}\n\n${post.data.description}`
+    )
+    .join('\n\n');
+
+  const faqSection = faqs.items
+    .map((faq) => `**Q: ${faq.question}**\nA: ${faq.answer}`)
+    .join('\n\n');
+
+  const membershipSection = membership.tiers
+    .map(
+      (tier) =>
+        `### ${tier.name} - $${tier.price}${tier.period}\n\n${tier.description}\n\n${tier.features.map((f) => `- ${f.text}`).join('\n')}`
+    )
+    .join('\n\n');
+
+  const experiencesSection = benefits.items
+    .map((item) => `### ${item.title}\n\n${item.description}`)
+    .join('\n\n');
+
+  const content = `# Pyre Sauna + Cold Plunge
+
+> Pyre is a modern communal bathhouse in Richmond, VA offering traditional Finnish saunas, cold plunge pools, and guided wellness experiences. We combine ancient sweat bathing traditions with modern community-focused wellness to help people release stress, reconnect, and feel more human together.
+
+## About
+
+${about.title}
+
+${about.body.join('\n\n')}
+
+## Experiences
+
+${benefits.subtitle}
+
+${experiencesSection}
+
+${benefits.closing}
+
+## Sessions and Booking
+
+Pyre offers sauna and cold plunge sessions that can be booked through our events page at ${baseUrl}/events. We recommend booking in advance to guarantee your preferred time slot. Walk-ins are welcome based on availability.
+
+### What to Expect
+
+Our facilities include traditional Finnish saunas reaching 170-195 F and cold plunge pools maintained at 39-50 F. We recommend the following protocol for optimal benefits:
+
+1. Sauna session: 10-20 minutes
+2. Cold plunge: 1-3 minutes
+3. Rest period
+4. Repeat 2-4 rounds
+
+### What to Bring
+
+Bring a swimsuit, a water bottle, and an optional robe or sandals. We provide towels and all the amenities you need for your session.
+
+## Memberships
+
+${membership.subtitle}
+
+${membershipSection}
+
+Note: ${membership.note}
+
+## Private Group Experiences
+
+${groupBooking.subtitle}
+
+${groupBooking.description.join('\n\n')}
+
+Capacity: ${groupBooking.capacity.label}
+
+### Available For
+
+${groupBooking.occasions.map((o) => `- ${o.label}`).join('\n')}
+
+Contact: groups@pyresauna.com
+
+## Blog
+
+${blogSection}
+
+## Frequently Asked Questions
+
+${faqSection}
+
+## Safety Information
+
+Contrast therapy (alternating sauna and cold plunge) is safe for healthy adults. However, if you have cardiovascular conditions, high blood pressure, or are pregnant, please consult your doctor before participating. Stay hydrated and listen to your body at all times.
+
+Our sauna masters hold certifications from the Deutsche Sauna-Akademie and Sherpa Breath and Cold.
+
+## Contact
+
+- **Email**: hi@pyresauna.com
+- **Group bookings**: groups@pyresauna.com
+- **Instagram**: https://instagram.com/pyre_sauna
+- **Website**: ${baseUrl}
+
+## Legal
+
+- [Privacy Policy](${baseUrl}/privacy-policy)
+- [Cookie Policy](${baseUrl}/cookie-policy)
+- [Terms of Service](${baseUrl}/terms-of-service)
+`;
+
+  return new Response(content, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': 'public, max-age=86400, s-maxage=86400',
+    },
+  });
+};

--- a/apps/landing-page/src/pages/llms.txt.ts
+++ b/apps/landing-page/src/pages/llms.txt.ts
@@ -1,11 +1,40 @@
+import { getCollection } from 'astro:content';
 import type { APIRoute } from 'astro';
+import experiences from '@/lib/experiences';
+import faqs from '@/lib/faqs';
+import membership from '@/lib/membership';
 
 export const prerender = true;
 
-export const GET: APIRoute = ({ site }) => {
-  const baseUrl = site?.origin ?? 'https://pyresauna.com';
+export const GET: APIRoute = async ({ site }) => {
+	const baseUrl = site?.origin ?? 'https://pyresauna.com';
 
-  const content = `# Pyre Sauna + Cold Plunge
+	// Fetch all published blog posts
+	const allPosts = await getCollection('blog', ({ data }) => !data.draft);
+	const sortedPosts = allPosts.sort(
+		(a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime(),
+	);
+
+	const experiencesList = experiences.items
+		.map((item) => `- [${item.title}](${baseUrl}/events): ${item.description}`)
+		.join('\n');
+
+	const membershipList = membership.tiers
+		.map(
+			(tier) =>
+				`- ${tier.name} ($${tier.price}${tier.period}): ${tier.features.map((f) => f.text).join(', ')}`,
+		)
+		.join('\n');
+
+	const blogList = sortedPosts
+		.map((post) => `- [${post.data.title}](${baseUrl}/blog/${post.slug}): ${post.data.description}`)
+		.join('\n');
+
+	const faqList = faqs.items
+		.map((faq) => `- ${faq.question}: ${faq.answer}`)
+		.join('\n');
+
+	const content = `# Pyre Sauna + Cold Plunge
 
 > Pyre is a modern communal bathhouse in Richmond, VA offering traditional Finnish saunas, cold plunge pools, and guided wellness experiences. We combine ancient sweat bathing traditions with modern community-focused wellness.
 
@@ -17,15 +46,12 @@ Pyre provides contrast therapy (sauna + cold plunge), guided sessions led by cer
 
 ## Experiences
 
-- [Free Flow Sessions](${baseUrl}/events): Move between saunas and cold plunges at your own pace
-- [Guided Sessions](${baseUrl}/events): Curated experiences by certified sauna masters blending sauna, cold plunge, breathwork, and movement
-- [Special Events](${baseUrl}/events): Sound baths, breathwork, drumming, guided meditations, and communal healing
+${experiencesList}
 - [Private Group Experiences](mailto:groups@pyresauna.com): Exclusive access for up to 25 guests for birthdays, corporate events, and celebrations
 
 ## Memberships
 
-- Limited Plan ($99/month): 4 sauna and cold plunge sessions, credits rollover 1 month, 10% off extra sessions
-- Unlimited Plan ($199/month): Unlimited access, free Pyre tote bag, 4 guest passes per month, 10% off extra guest sessions
+${membershipList}
 
 ## Facilities
 
@@ -36,21 +62,11 @@ Pyre provides contrast therapy (sauna + cold plunge), guided sessions led by cer
 
 ## Blog
 
-- [The Science-Backed Health Benefits of Regular Sauna Use](${baseUrl}/blog/sauna-health-benefits): How regular sauna sessions improve cardiovascular function, mental wellness, and muscle recovery
-- [The Science Behind Cold Plunging](${baseUrl}/blog/cold-plunge-benefits): Health benefits of cold water immersion and best practices
-- [The Loneliness Epidemic: How Social Sauna Builds Connection](${baseUrl}/blog/social-sauna-combating-loneliness): How communal sauna bathing combats isolation and builds community
-- [Activating the Vagus Nerve](${baseUrl}/blog/vagus-nerve-wellness): How sauna, cold plunge, and breathwork enhance well-being through vagus nerve stimulation
-- [Ancient Wisdom, Modern Wellness](${baseUrl}/blog/history-of-sweat-bathing): The global history of sweat bathing traditions
-- [Our Mission, Vision, and Values](${baseUrl}/blog/our-mission-vision-values): The guiding principles behind Pyre
+${blogList}
 
 ## FAQ
 
-- What should I bring?: Swimsuit, water bottle, optional robe/sandals. Towels and amenities provided.
-- How hot does the sauna get?: 170-195 F (traditional Finnish sauna temperatures).
-- How cold is the cold plunge?: 39-50 F. Start with shorter immersions and increase gradually.
-- Is contrast therapy safe?: Safe for healthy adults. Consult a doctor if you have cardiovascular conditions, high blood pressure, or are pregnant.
-- Recommended session protocol: 10-20 min sauna, 1-3 min cold plunge, repeat 2-4 rounds.
-- Do I need to book?: Yes, booking in advance recommended. Walk-ins welcome based on availability.
+${faqList}
 
 ## Legal
 
@@ -64,11 +80,11 @@ Pyre provides contrast therapy (sauna + cold plunge), guided sessions led by cer
 - [Sitemap](${baseUrl}/sitemap-index.xml): XML sitemap for all pages
 `;
 
-  return new Response(content, {
-    status: 200,
-    headers: {
-      'Content-Type': 'text/markdown; charset=utf-8',
-      'Cache-Control': 'public, max-age=86400, s-maxage=86400',
-    },
-  });
+	return new Response(content, {
+		status: 200,
+		headers: {
+			'Content-Type': 'text/markdown; charset=utf-8',
+			'Cache-Control': 'public, max-age=86400, s-maxage=86400',
+		},
+	});
 };

--- a/apps/landing-page/src/pages/llms.txt.ts
+++ b/apps/landing-page/src/pages/llms.txt.ts
@@ -1,0 +1,74 @@
+import type { APIRoute } from 'astro';
+
+export const prerender = true;
+
+export const GET: APIRoute = ({ site }) => {
+  const baseUrl = site?.origin ?? 'https://pyresauna.com';
+
+  const content = `# Pyre Sauna + Cold Plunge
+
+> Pyre is a modern communal bathhouse in Richmond, VA offering traditional Finnish saunas, cold plunge pools, and guided wellness experiences. We combine ancient sweat bathing traditions with modern community-focused wellness.
+
+Pyre provides contrast therapy (sauna + cold plunge), guided sessions led by certified sauna masters, and special events including breathwork, sound baths, and group experiences. We focus on authentic human connection and science-backed wellness practices.
+
+- Contact: hi@pyresauna.com
+- Instagram: https://instagram.com/pyre_sauna
+- Group bookings: groups@pyresauna.com
+
+## Experiences
+
+- [Free Flow Sessions](${baseUrl}/events): Move between saunas and cold plunges at your own pace
+- [Guided Sessions](${baseUrl}/events): Curated experiences by certified sauna masters blending sauna, cold plunge, breathwork, and movement
+- [Special Events](${baseUrl}/events): Sound baths, breathwork, drumming, guided meditations, and communal healing
+- [Private Group Experiences](mailto:groups@pyresauna.com): Exclusive access for up to 25 guests for birthdays, corporate events, and celebrations
+
+## Memberships
+
+- Limited Plan ($99/month): 4 sauna and cold plunge sessions, credits rollover 1 month, 10% off extra sessions
+- Unlimited Plan ($199/month): Unlimited access, free Pyre tote bag, 4 guest passes per month, 10% off extra guest sessions
+
+## Facilities
+
+- Traditional Finnish saunas (170-195 F)
+- Cold plunge pools (39-50 F)
+- Towels and amenities provided
+- Bring: swimsuit, water bottle, optional robe/sandals
+
+## Blog
+
+- [The Science-Backed Health Benefits of Regular Sauna Use](${baseUrl}/blog/sauna-health-benefits): How regular sauna sessions improve cardiovascular function, mental wellness, and muscle recovery
+- [The Science Behind Cold Plunging](${baseUrl}/blog/cold-plunge-benefits): Health benefits of cold water immersion and best practices
+- [The Loneliness Epidemic: How Social Sauna Builds Connection](${baseUrl}/blog/social-sauna-combating-loneliness): How communal sauna bathing combats isolation and builds community
+- [Activating the Vagus Nerve](${baseUrl}/blog/vagus-nerve-wellness): How sauna, cold plunge, and breathwork enhance well-being through vagus nerve stimulation
+- [Ancient Wisdom, Modern Wellness](${baseUrl}/blog/history-of-sweat-bathing): The global history of sweat bathing traditions
+- [Our Mission, Vision, and Values](${baseUrl}/blog/our-mission-vision-values): The guiding principles behind Pyre
+
+## FAQ
+
+- What should I bring?: Swimsuit, water bottle, optional robe/sandals. Towels and amenities provided.
+- How hot does the sauna get?: 170-195 F (traditional Finnish sauna temperatures).
+- How cold is the cold plunge?: 39-50 F. Start with shorter immersions and increase gradually.
+- Is contrast therapy safe?: Safe for healthy adults. Consult a doctor if you have cardiovascular conditions, high blood pressure, or are pregnant.
+- Recommended session protocol: 10-20 min sauna, 1-3 min cold plunge, repeat 2-4 rounds.
+- Do I need to book?: Yes, booking in advance recommended. Walk-ins welcome based on availability.
+
+## Legal
+
+- [Privacy Policy](${baseUrl}/privacy-policy)
+- [Cookie Policy](${baseUrl}/cookie-policy)
+- [Terms of Service](${baseUrl}/terms-of-service)
+
+## Optional
+
+- [Full content for LLMs](${baseUrl}/llms-full.txt): Comprehensive site content in a single file
+- [Sitemap](${baseUrl}/sitemap-index.xml): XML sitemap for all pages
+`;
+
+  return new Response(content, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': 'public, max-age=86400, s-maxage=86400',
+    },
+  });
+};

--- a/apps/landing-page/src/pages/robots.txt.ts
+++ b/apps/landing-page/src/pages/robots.txt.ts
@@ -1,0 +1,56 @@
+import type { APIRoute } from 'astro';
+
+export const prerender = true;
+
+export const GET: APIRoute = ({ site }) => {
+  const baseUrl = site?.origin ?? 'https://pyresauna.com';
+
+  const content = `# Robots.txt for Pyre Sauna + Cold Plunge
+# https://pyresauna.com
+
+# Allow all crawlers
+User-agent: *
+Allow: /
+Disallow: /api/
+Disallow: /account/
+
+# AI Crawlers - explicitly welcome
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: cohere-ai
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+# Sitemap and LLMs.txt
+Sitemap: ${baseUrl}/sitemap-index.xml
+`;
+
+  return new Response(content, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=86400, s-maxage=86400',
+    },
+  });
+};

--- a/apps/landing-page/src/pages/robots.txt.ts
+++ b/apps/landing-page/src/pages/robots.txt.ts
@@ -1,0 +1,22 @@
+import type { APIRoute } from 'astro';
+
+export const prerender = true;
+
+export const GET: APIRoute = ({ site }) => {
+	const siteUrl = site?.toString().replace(/\/$/, '') ?? 'https://pyresauna.com';
+
+	const robotsTxt = [
+		'User-agent: *',
+		'Allow: /',
+		'',
+		'# Block API and account routes',
+		'Disallow: /api/',
+		'Disallow: /account/',
+		'',
+		`Sitemap: ${siteUrl}/sitemap-index.xml`,
+	].join('\n');
+
+	return new Response(robotsTxt, {
+		headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+	});
+};


### PR DESCRIPTION
- Add /llms.txt with site overview, experiences, memberships, FAQ, and blog links
- Add /llms-full.txt with comprehensive content pulled from config files and blog collection
- Add /robots.txt with explicit AI bot permissions (GPTBot, ClaudeBot, PerplexityBot, etc.)
- Add <link rel="alternate" type="text/markdown"> tag for llms.txt discovery in HTML head
- Add HealthAndBeautyBusiness JSON-LD structured data on homepage with offers catalog

https://claude.ai/code/session_01XKPgoBkjbhQuGfB18zBwhE