### PR TITLE
Add mailing list link to mobile hero and mobile menu

### DIFF
--- a/apps/landing-page/src/components/Hero.astro
+++ b/apps/landing-page/src/components/Hero.astro
@@ -32,7 +32,7 @@ import InstagramIcon from './icons/InstagramIcon.astro';
 
 
     <!-- Contact Info -->
-    <div class="space-y-6 my-8">
+    <div class="space-y-4 my-6">
       <div>
         <h2 class="font-mono-bold text-xs uppercase tracking-wider opacity-60 mb-1">Address</h2>
         <a href={location.mapsUrl} target="_blank" rel="noopener noreferrer" class="text-base md:text-lg hover:underline underline-offset-4">{location.address}</a>
@@ -55,7 +55,7 @@ import InstagramIcon from './icons/InstagramIcon.astro';
     </div>
 
     <!-- Hours -->
-    <div class="pb-6">
+    <div class="pb-4">
       <h2 class="font-mono-bold text-xs uppercase tracking-wider opacity-60 mb-3">Soft Opening Hours</h2>
       <div class="grid grid-rows-3 grid-flow-col gap-x-8 gap-y-1 text-sm md:text-base">
         {location.hours.map((h) => (

--- a/apps/landing-page/src/components/Hero.astro
+++ b/apps/landing-page/src/components/Hero.astro
@@ -49,6 +49,9 @@ import InstagramIcon from './icons/InstagramIcon.astro';
           {location.instagram}
         </a>
       </div>
+      <div>
+        <a href="#signup" class="text-lg hover:underline underline-offset-4 text-[var(--pyre-red)]">Join Our Mailing List</a>
+      </div>
     </div>
 
     <!-- Hours -->

--- a/apps/landing-page/src/components/Navbar.astro
+++ b/apps/landing-page/src/components/Navbar.astro
@@ -1,9 +1,11 @@
 ---
 import pyreLogoRaw from '../assets/logos/pyre_logo.svg?raw';
+import location from '../lib/location';
 import navbar from '../lib/navbar';
 import { withBase } from '../lib/paths';
 import Button from './Button.astro';
 import GradientOverlay from './GradientOverlay.astro';
+import InstagramIcon from './icons/InstagramIcon.astro';
 
 interface Props {
   isHomePage?: boolean;
@@ -139,6 +141,23 @@ const pyreLogo = pyreLogoRaw.replace('<svg', '<svg class="h-full w-auto"');
           {link.label}
         </a>
       ))}
+      <a
+        href={location.instagramUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Follow us on Instagram"
+        class="inline-flex items-center gap-1.5 font-mono-bold text-sm uppercase tracking-wide text-[var(--pyre-creme)] py-2 hover:opacity-70 transition-opacity"
+      >
+        <InstagramIcon class="size-[1.1em] shrink-0" />
+        Instagram
+      </a>
+      <a
+        href="#signup"
+        aria-label="Join our mailing list"
+        class="font-mono-bold text-sm uppercase tracking-wide text-[var(--pyre-red)] py-2 hover:opacity-70 transition-opacity"
+      >
+        Join Mailing List
+      </a>
       <div class="pt-3 border-t border-[var(--pyre-creme)]/10 flex flex-row items-start gap-3">
         <!-- <div class="w-full">
           <AuthButtons


### PR DESCRIPTION
## Summary
- Add "Join Our Mailing List" link to the mobile hero contact info section (`Hero.astro`), matching the existing desktop hero styling (pyre-red, links to `#signup`)
- Add Instagram (with icon, links to profile) and "Join Mailing List" (pyre-red, links to `#signup`) links to the mobile navigation menu (`Navbar.astro`)

## Test plan
- [ ] Open the landing page on a mobile viewport and verify the "Join Our Mailing List" link appears in the hero below Instagram
- [ ] Tap the link and confirm it smooth-scrolls to the signup section
- [ ] Open the mobile hamburger menu and verify Instagram and Join Mailing List links appear
- [ ] Verify desktop layout is unchanged

https://claude.ai/code/session_01J2uBHUQpNdv56yRatW6b2q