### PR TITLE
Disable PostHog analytics in local development

### DIFF
--- a/apps/landing-page/src/layouts/main.astro
+++ b/apps/landing-page/src/layouts/main.astro
@@ -251,7 +251,7 @@ const llmsTxtUrl = Astro.site
 			</>
 		)}
 
-		<PostHog />
+		{import.meta.env.PROD && <PostHog />}
 		<script>
 			// Disable browser's automatic scroll restoration
 			if ('scrollRestoration' in history) {


### PR DESCRIPTION
Only render the PostHog script in production builds using Astro's import.meta.env.PROD flag, preventing dev traffic from polluting analytics.