### PR TITLE
Add Momence webhook for Mailchimp subscriber sync

### DIFF
--- a/apps/landing-page/src/lib/webhooks/logger.ts
+++ b/apps/landing-page/src/lib/webhooks/logger.ts
@@ -1,0 +1,37 @@
+export interface WebhookLogger {
+  info(message: string, data?: Record<string, unknown>): void;
+  warn(message: string, data?: Record<string, unknown>): void;
+  error(message: string, error?: unknown, data?: Record<string, unknown>): void;
+}
+
+export function createWebhookLogger(prefix: string): WebhookLogger {
+  const tag = `[Webhook: ${prefix}]`;
+
+  return {
+    info(message, data) {
+      if (data) {
+        console.log(tag, message, data);
+      } else {
+        console.log(tag, message);
+      }
+    },
+
+    warn(message, data) {
+      if (data) {
+        console.warn(tag, message, data);
+      } else {
+        console.warn(tag, message);
+      }
+    },
+
+    error(message, error, data) {
+      if (error && data) {
+        console.error(tag, message, error, data);
+      } else if (error) {
+        console.error(tag, message, error);
+      } else {
+        console.error(tag, message);
+      }
+    },
+  };
+}

--- a/apps/landing-page/src/lib/webhooks/mailchimp.ts
+++ b/apps/landing-page/src/lib/webhooks/mailchimp.ts
@@ -1,0 +1,136 @@
+import { createHash } from 'node:crypto';
+import { createWebhookLogger } from './logger';
+
+const log = createWebhookLogger('Mailchimp');
+
+function getConfig() {
+  const apiKey = import.meta.env.MAILCHIMP_API_KEY;
+  const audienceId = import.meta.env.MAILCHIMP_AUDIENCE_ID;
+
+  if (!apiKey) throw new Error('MAILCHIMP_API_KEY not configured');
+  if (!audienceId) throw new Error('MAILCHIMP_AUDIENCE_ID not configured');
+
+  // API key format: "key-dc" (e.g., "abc123-us18")
+  const dc = apiKey.split('-').pop();
+  const baseUrl = `https://${dc}.api.mailchimp.com/3.0`;
+
+  const headers = {
+    Authorization: `Basic ${Buffer.from(`anystring:${apiKey}`).toString('base64')}`,
+    'Content-Type': 'application/json',
+  };
+
+  return { baseUrl, audienceId, headers };
+}
+
+function getSubscriberHash(email: string): string {
+  return createHash('md5').update(email.toLowerCase()).digest('hex');
+}
+
+// --- Subscriber management ---
+
+export interface UpsertSubscriberParams {
+  email: string;
+  firstName: string;
+  lastName: string;
+}
+
+export async function upsertSubscriber({
+  email,
+  firstName,
+  lastName,
+}: UpsertSubscriberParams): Promise<void> {
+  const { baseUrl, audienceId, headers } = getConfig();
+  const hash = getSubscriberHash(email);
+
+  log.info(`Upserting subscriber ${email}`);
+
+  const response = await fetch(`${baseUrl}/lists/${audienceId}/members/${hash}`, {
+    method: 'PUT',
+    headers,
+    body: JSON.stringify({
+      email_address: email,
+      status_if_new: 'subscribed',
+      merge_fields: {
+        FNAME: firstName,
+        LNAME: lastName,
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(`Mailchimp upsert failed (${response.status}): ${error.detail}`);
+  }
+
+  log.info(`Subscriber ${email} upserted successfully`);
+}
+
+// --- Tags ---
+
+export interface SubscriberTag {
+  name: string;
+  status: 'active' | 'inactive';
+}
+
+export async function setSubscriberTags(email: string, tags: SubscriberTag[]): Promise<void> {
+  const { baseUrl, audienceId, headers } = getConfig();
+  const hash = getSubscriberHash(email);
+
+  log.info(`Setting tags on ${email}`, { tags: tags.map((t) => t.name) });
+
+  const response = await fetch(`${baseUrl}/lists/${audienceId}/members/${hash}/tags`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ tags }),
+  });
+
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(`Mailchimp tags failed (${response.status}): ${error.detail}`);
+  }
+
+  log.info(`Tags set on ${email} successfully`);
+}
+
+// --- Address ---
+
+export interface SubscriberAddress {
+  addr1: string;
+  city: string;
+  zip: string;
+  country: string;
+}
+
+export async function updateSubscriberAddress(
+  email: string,
+  address: SubscriberAddress | null
+): Promise<void> {
+  const { baseUrl, audienceId, headers } = getConfig();
+  const hash = getSubscriberHash(email);
+
+  log.info(`Updating address for ${email}`, { address });
+
+  const response = await fetch(`${baseUrl}/lists/${audienceId}/members/${hash}`, {
+    method: 'PATCH',
+    headers,
+    body: JSON.stringify({
+      merge_fields: {
+        ADDRESS: address
+          ? {
+              addr1: address.addr1,
+              city: address.city,
+              zip: address.zip,
+              country: address.country,
+            }
+          : { addr1: '', city: '', zip: '', country: '' },
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(`Mailchimp address update failed (${response.status}): ${error.detail}`);
+  }
+
+  log.info(`Address updated for ${email} successfully`);
+}

--- a/apps/landing-page/src/lib/webhooks/momence.ts
+++ b/apps/landing-page/src/lib/webhooks/momence.ts
@@ -1,0 +1,127 @@
+import { createHmac } from 'node:crypto';
+import { createWebhookLogger } from './logger';
+
+const log = createWebhookLogger('Momence');
+
+const MOMENCE_API_BASE = 'https://api.momence.com/api/v1';
+
+// --- Types ---
+
+export interface MomenceMemberPayload {
+  memberId: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+}
+
+export interface MomenceAddressPayload {
+  memberAddressId: string;
+  memberId: string;
+  address: string;
+  zipcode: string;
+  city: string;
+  country: string;
+}
+
+export type MomenceEventType =
+  | 'member-assigned'
+  | 'member-updated'
+  | 'member-address-created'
+  | 'member-address-updated'
+  | 'member-address-deleted';
+
+export interface MomenceWebhookResult<T = unknown> {
+  event: string;
+  payload: T;
+  requestId: string;
+  timestamp: string;
+}
+
+// --- Verification ---
+
+export class WebhookVerificationError extends Error {
+  constructor(
+    message: string,
+    public statusCode: number
+  ) {
+    super(message);
+    this.name = 'WebhookVerificationError';
+  }
+}
+
+export async function verifyMomenceWebhook(request: Request): Promise<MomenceWebhookResult> {
+  const secret = request.headers.get('x-webhook-secret');
+  const expectedSecret = import.meta.env.MOMENCE_WEBHOOK_SECRET;
+
+  if (!expectedSecret) {
+    throw new WebhookVerificationError('MOMENCE_WEBHOOK_SECRET not configured', 500);
+  }
+
+  if (secret !== expectedSecret) {
+    throw new WebhookVerificationError('Invalid webhook secret', 401);
+  }
+
+  const body = await request.json();
+  const payloadString: string = body.payload;
+
+  if (!payloadString || typeof payloadString !== 'string') {
+    throw new WebhookVerificationError('Missing or invalid payload', 400);
+  }
+
+  // Verify HMAC-SHA256 signature
+  const signature = request.headers.get('x-webhook-signature');
+  const signingSecret = import.meta.env.MOMENCE_WEBHOOK_SIGNING_SECRET;
+
+  if (signingSecret && signature) {
+    const expectedSignature = createHmac('sha256', signingSecret)
+      .update(payloadString)
+      .digest('hex');
+    if (signature !== expectedSignature) {
+      throw new WebhookVerificationError('Invalid webhook signature', 401);
+    }
+  }
+
+  const parsed = JSON.parse(payloadString);
+  // Note: Momence has a typo in the header name ("reqeuest" instead of "request")
+  const requestId = request.headers.get('x-webhook-reqeuest-id') ?? 'unknown';
+
+  return {
+    event: parsed.event,
+    payload: parsed.payload,
+    requestId,
+    timestamp: parsed.timestamp,
+  };
+}
+
+// --- Member lookup ---
+
+export async function fetchMomenceMember(
+  memberId: string
+): Promise<{ email: string; firstName: string; lastName: string }> {
+  const hostId = import.meta.env.MOMENCE_HOST_ID;
+  const apiToken = import.meta.env.MOMENCE_API_TOKEN;
+
+  if (!hostId || !apiToken) {
+    throw new Error('Missing Momence API credentials (MOMENCE_HOST_ID or MOMENCE_API_TOKEN)');
+  }
+
+  const url = `${MOMENCE_API_BASE}/host/${hostId}/members/${memberId}?token=${apiToken}`;
+
+  log.info(`Fetching member ${memberId} from Momence API`);
+
+  const response = await fetch(url, {
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Momence API returned ${response.status} for member ${memberId}`);
+  }
+
+  const data = await response.json();
+
+  return {
+    email: data.email,
+    firstName: data.firstName,
+    lastName: data.lastName,
+  };
+}

--- a/apps/landing-page/src/pages/api/webhooks/momence.ts
+++ b/apps/landing-page/src/pages/api/webhooks/momence.ts
@@ -1,0 +1,92 @@
+import type { APIRoute } from 'astro';
+import { createWebhookLogger } from '@/lib/webhooks/logger';
+import {
+  setSubscriberTags,
+  updateSubscriberAddress,
+  upsertSubscriber,
+} from '@/lib/webhooks/mailchimp';
+import {
+  fetchMomenceMember,
+  type MomenceAddressPayload,
+  type MomenceEventType,
+  type MomenceMemberPayload,
+  verifyMomenceWebhook,
+  WebhookVerificationError,
+} from '@/lib/webhooks/momence';
+
+export const prerender = false;
+
+const log = createWebhookLogger('Momence');
+
+const MEMBER_EVENTS: MomenceEventType[] = ['member-assigned', 'member-updated'];
+const ADDRESS_EVENTS: MomenceEventType[] = [
+  'member-address-created',
+  'member-address-updated',
+  'member-address-deleted',
+];
+
+async function handleMemberEvent(
+  event: MomenceEventType,
+  payload: MomenceMemberPayload
+): Promise<void> {
+  const { email, firstName, lastName } = payload;
+
+  await upsertSubscriber({ email, firstName, lastName });
+
+  if (event === 'member-assigned') {
+    await setSubscriberTags(email, [{ name: 'Active Guest', status: 'active' }]);
+  }
+}
+
+async function handleAddressEvent(
+  event: MomenceEventType,
+  payload: MomenceAddressPayload
+): Promise<void> {
+  const member = await fetchMomenceMember(payload.memberId);
+
+  if (event === 'member-address-deleted') {
+    await updateSubscriberAddress(member.email, null);
+  } else {
+    await updateSubscriberAddress(member.email, {
+      addr1: payload.address,
+      city: payload.city,
+      zip: payload.zipcode,
+      country: payload.country,
+    });
+  }
+}
+
+export const POST: APIRoute = async ({ request }) => {
+  try {
+    const { event, payload, requestId } = await verifyMomenceWebhook(request);
+
+    log.info(`Received event: ${event}`, { requestId });
+
+    if (MEMBER_EVENTS.includes(event as MomenceEventType)) {
+      await handleMemberEvent(event as MomenceEventType, payload as MomenceMemberPayload);
+    } else if (ADDRESS_EVENTS.includes(event as MomenceEventType)) {
+      await handleAddressEvent(event as MomenceEventType, payload as MomenceAddressPayload);
+    } else {
+      log.info(`Ignoring unhandled event: ${event}`);
+    }
+
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    if (error instanceof WebhookVerificationError) {
+      log.error(`Verification failed: ${error.message}`);
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: error.statusCode,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    log.error('Webhook processing failed', error);
+    return new Response(JSON.stringify({ error: 'Internal server error' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};


### PR DESCRIPTION
## Summary
- Replaces the Zapier "Momence > Mailchimp" zap with a Vercel-hosted webhook endpoint at `/api/webhooks/momence`
- Handles 5 Momence events: `member-assigned`, `member-updated`, `member-address-created`, `member-address-updated`, `member-address-deleted`
- Shared utilities extracted for reuse by future webhooks (logger, Momence verification, Mailchimp client)

## New files
| File | Purpose |
|---|---|
| `src/lib/webhooks/logger.ts` | Centralized webhook logger — add alerting here later |
| `src/lib/webhooks/momence.ts` | Webhook verification + member lookup via Momence API |
| `src/lib/webhooks/mailchimp.ts` | Upsert subscriber, set tags, update address |
| `src/pages/api/webhooks/momence.ts` | Route handler for all Momence events |

## New env vars needed
- `MOMENCE_WEBHOOK_SECRET` — from Momence dashboard
- `MOMENCE_WEBHOOK_SIGNING_SECRET` — from Momence dashboard
- `MAILCHIMP_API_KEY` — Mailchimp API key (ending in `-us18`)
- `MAILCHIMP_AUDIENCE_ID` — Mailchimp audience/list ID

## Test plan
- [ ] Add env vars to Vercel project settings
- [ ] Deploy preview and test with `curl` for each event type
- [ ] Verify subscriber appears in Mailchimp with correct fields and "Active Guest" tag
- [ ] Verify address sync works for create/update/delete
- [ ] Configure webhook URL in Momence dashboard
- [ ] Test with real member interaction
- [ ] Disable the Zapier zap

🤖 Generated with [Claude Code](https://claude.com/claude-code)