### PR TITLE
Fix shop image hover rotation blocked by pointer-events-none

### DIFF
--- a/apps/landing-page/src/components/shop/ProductCard.astro
+++ b/apps/landing-page/src/components/shop/ProductCard.astro
@@ -135,8 +135,26 @@ const needsStockCheck = !!product.momenceId;
         });
       }
 
+      // Desktop: hover to cycle
       gallery.addEventListener('mouseenter', () => show(current + 1));
       gallery.addEventListener('mouseleave', () => show(0));
+
+      // Mobile: tap image to cycle (distinguish taps from scrolls)
+      let touchStartY = 0;
+      let touchStartX = 0;
+      gallery.addEventListener('touchstart', (e) => {
+        touchStartX = e.touches[0].clientX;
+        touchStartY = e.touches[0].clientY;
+      }, { passive: true });
+
+      gallery.addEventListener('touchend', (e) => {
+        const dx = e.changedTouches[0].clientX - touchStartX;
+        const dy = e.changedTouches[0].clientY - touchStartY;
+        if (Math.abs(dx) < 15 && Math.abs(dy) < 15) {
+          e.preventDefault();
+          show(current + 1);
+        }
+      });
     });
   }
 

--- a/apps/landing-page/src/pages/shop/index.astro
+++ b/apps/landing-page/src/pages/shop/index.astro
@@ -171,14 +171,22 @@ const categories = [...new Set(products.map((p) => p.category))].sort();
     for (const item of items) grid.appendChild(item);
   }
 
+  function enableAllCards() {
+    document.querySelectorAll<HTMLElement>('[data-momence-id]').forEach((card) => {
+      card.classList.remove('pointer-events-none');
+      card.classList.add('hover:bg-[var(--pyre-creme)]/8');
+    });
+  }
+
   async function hydrateStock() {
     const base = import.meta.env.BASE_URL ?? '/';
     let data: StockMap;
     try {
       const res = await fetch(`${base}api/shop-stock`.replace(/\/\//g, '/'));
-      if (!res.ok) return;
+      if (!res.ok) { enableAllCards(); return; }
       data = await res.json();
     } catch {
+      enableAllCards();
       return;
     }
 
@@ -203,9 +211,14 @@ const categories = [...new Set(products.map((p) => p.category))].sort();
         if (variantsEl) renderVariants(variantsEl, stock.variants);
       }
 
+      // Enable pointer events now that stock is known so hover gallery works
+      card.classList.remove('pointer-events-none');
+
       if (stock.soldOut) {
         anySoldOut = true;
         applySoldOutState(card);
+      } else {
+        card.classList.add('hover:bg-[var(--pyre-creme)]/8');
       }
     });
 


### PR DESCRIPTION
Products with stock checks had pointer-events-none applied during loading,
which prevented the gallery mouseenter/mouseleave events from firing.
Now pointer-events are re-enabled after stock hydration completes, and
also on fetch failure as a fallback.

https://claude.ai/code/session_01V5fTwRYTkLZZe16uSP1XK6