### PR TITLE
Add inline raffle signup under Rest Fest prizes

### DIFF
--- a/apps/landing-page/src/components/SignupForm.astro
+++ b/apps/landing-page/src/components/SignupForm.astro
@@ -5,6 +5,7 @@ import SectionDivider from './SectionDivider.astro';
 
 interface Props {
   variant?: 'default' | 'compact';
+  formKey?: string;
   tagId?: string;
   posthogSource?: string;
   title?: string;
@@ -14,6 +15,7 @@ interface Props {
 
 const {
   variant = 'default',
+  formKey,
   tagId,
   posthogSource,
   title,
@@ -31,7 +33,7 @@ const resolvedSuccessMessage = successMessage ?? signupForm.elements.successMess
 const subscribed =
   Astro.url.searchParams.get(signupForm.metadata?.subscribedParam ?? 'subscribed') === '1';
 
-const idSuffix = isCompact ? '-compact' : '';
+const idSuffix = formKey ? `-${formKey}` : isCompact ? '-compact' : '';
 const headingId = `signup-heading${idSuffix}`;
 const emailId = `signup-email${idSuffix}`;
 

--- a/apps/landing-page/src/layouts/main.astro
+++ b/apps/landing-page/src/layouts/main.astro
@@ -45,6 +45,7 @@ interface Props {
   transparentNav?: boolean;
   darkLogoText?: boolean;
   noIndex?: boolean;
+  hidePromos?: boolean;
 }
 
 const {
@@ -59,6 +60,7 @@ const {
   transparentNav = false,
   darkLogoText = false,
   noIndex = false,
+  hidePromos = false,
 } = Astro.props;
 
 const base = import.meta.env.BASE_URL ?? '/';
@@ -369,13 +371,13 @@ const llmsTxtUrl = Astro.site ? new URL('/llms.txt', Astro.site).toString() : '/
 		</script>
 	</head>
     <body class="min-h-screen flex flex-col">
-        <AnnouncementBanner />
+        {!hidePromos && <AnnouncementBanner />}
         <Navbar isHomePage={isHomePage} transparentNav={transparentNav || isHomePage} darkLogoText={darkLogoText} minimal={isAdminRoute} />
         <div id="nav-sentinel" aria-hidden="true" class="h-px w-0"></div>
 		<main class="flex-1" style="padding-top: var(--banner-height, 0px);">
 			<slot />
 		</main>
 		{!isAdminRoute && <Footer />}
-		<PromoPopup />
+		{!hidePromos && <PromoPopup />}
 	</body>
 </html>

--- a/apps/landing-page/src/lib/restFest.ts
+++ b/apps/landing-page/src/lib/restFest.ts
@@ -22,10 +22,9 @@ const restFest: RestFestContent = {
   posthogSource: 'restfest_2026',
   eventsUrl: '/events?utm_source=restfest2026&utm_medium=event&utm_campaign=rest_fest_2026',
   signupCopy: {
-    title: 'JOIN THE LIST',
-    subtitle:
-      'Sign up to enter the raffle and hear about pre-opening sessions, soft-open events, and Grand Opening.',
-    successMessage: "You're in. We'll be in touch.",
+    title: 'Enter the raffle',
+    subtitle: "Drop your email to enter and we'll send you pre-opening session invites.",
+    successMessage: "You're entered. Good luck — we'll be in touch.",
   },
   prizes: [
     { name: 'Founding Unlimited Membership', count: 1, note: 'Valid for 6 months from Grand Opening' },

--- a/apps/landing-page/src/pages/rest-fest-2026.astro
+++ b/apps/landing-page/src/pages/rest-fest-2026.astro
@@ -129,9 +129,9 @@ const pageDescription =
             formKey="raffle"
             tagId={restFest.tagId}
             posthogSource={restFest.posthogSource}
-            title="Enter the raffle"
-            subtitle="Drop your email to enter and we'll send you pre-opening session invites."
-            successMessage="You're entered. Good luck — we'll be in touch."
+            title={restFest.signupCopy.title}
+            subtitle={restFest.signupCopy.subtitle}
+            successMessage={restFest.signupCopy.successMessage}
           />
         </div>
       </div>
@@ -274,22 +274,6 @@ const pageDescription =
         >
           See upcoming sessions
         </Button>
-      </div>
-    </section>
-
-  
-    <!-- Email signup -->
-    <section aria-labelledby="signup-heading" class="px-4 border-t border-current/10">
-      <div class="max-w-2xl mx-auto">
-        <SignupForm
-          variant="compact"
-          formKey="footer"
-          tagId={restFest.tagId}
-          posthogSource={restFest.posthogSource}
-          title={restFest.signupCopy.title}
-          subtitle={restFest.signupCopy.subtitle}
-          successMessage={restFest.signupCopy.successMessage}
-        />
       </div>
     </section>
 

--- a/apps/landing-page/src/pages/rest-fest-2026.astro
+++ b/apps/landing-page/src/pages/rest-fest-2026.astro
@@ -28,6 +28,7 @@ const pageDescription =
   ogImageWidth={heroImg.width}
   ogImageHeight={heroImg.height}
   noIndex={true}
+  hidePromos={true}
 >
   <div class="dark bg-[var(--pyre-black)] text-[var(--pyre-creme)]">
     <!-- Hero -->

--- a/apps/landing-page/src/pages/rest-fest-2026.astro
+++ b/apps/landing-page/src/pages/rest-fest-2026.astro
@@ -90,7 +90,7 @@ const pageDescription =
             The Rest Fest Raffle
           </h2>
           <p class="text-base md:text-lg opacity-80 max-w-2xl mx-auto">
-            Sign up below for the email list <em>or</em> book a session to enter. Winners drawn the week after Rest Fest.
+            Sign up for the email list <em>or</em> book a session to enter. Winners drawn the week after Rest Fest.
           </p>
           <SectionDivider
             variant="wave"
@@ -121,6 +121,18 @@ const pageDescription =
             </li>
           ))}
         </ul>
+
+        <div class="mt-10 md:mt-12 max-w-xl mx-auto">
+          <SignupForm
+            variant="compact"
+            formKey="raffle"
+            tagId={restFest.tagId}
+            posthogSource={restFest.posthogSource}
+            title="Enter the raffle"
+            subtitle="Drop your email to enter and we'll send you pre-opening session invites."
+            successMessage="You're entered. Good luck — we'll be in touch."
+          />
+        </div>
       </div>
     </section>
 
@@ -270,6 +282,7 @@ const pageDescription =
       <div class="max-w-2xl mx-auto">
         <SignupForm
           variant="compact"
+          formKey="footer"
           tagId={restFest.tagId}
           posthogSource={restFest.posthogSource}
           title={restFest.signupCopy.title}


### PR DESCRIPTION
Place a compact signup form directly below the prize grid so visitors
can enter the raffle without scrolling. Adds a formKey prop to
SignupForm so two compact forms on the same page get unique element IDs.