### PR TITLE
perf(landing-page): shrink critical path on /events and homepage

### DIFF
--- a/apps/landing-page/src/components/AboutSection.astro
+++ b/apps/landing-page/src/components/AboutSection.astro
@@ -1,5 +1,5 @@
 ---
-import { Image } from 'astro:assets';
+import { Picture } from 'astro:assets';
 import warmSauna from '../assets/images/warm_sauna.webp';
 import about from '../lib/about';
 import Button from './Button.astro';
@@ -10,13 +10,15 @@ import SectionDivider from './SectionDivider.astro';
   <div class="max-w-3xl mx-auto lg:max-w-none grid grid-cols-1 md:grid-cols-[1fr_1.5fr] gap-6 lg:gap-8 items-start">
     <!-- Image column -->
     <div class="aspect-[3/4] overflow-hidden rounded-lg">
-      <Image
+      <Picture
         src={warmSauna}
+        formats={['webp']}
+        widths={[400, 600, 800, 1000]}
+        sizes="(max-width: 768px) 100vw, 40vw"
         alt="People enjoying a social sauna session"
         class="w-full h-full object-cover object-center"
         loading="lazy"
         decoding="async"
-        fetchpriority="auto"
       />
     </div>
 

--- a/apps/landing-page/src/components/HeroCarousel.astro
+++ b/apps/landing-page/src/components/HeroCarousel.astro
@@ -8,6 +8,7 @@ import tiled from '../assets/backgrounds/tiled_upscale.png';
   formats={['webp']}
   widths={[640, 960, 1200, 1600]}
   sizes="(max-width: 1023px) 100vw, 60vw"
+  quality={70}
   width={1200}
   height={800}
   alt="Tiled background"

--- a/apps/landing-page/src/components/PromoPopup.astro
+++ b/apps/landing-page/src/components/PromoPopup.astro
@@ -557,11 +557,24 @@ const hasForm = !!promoConfig.form;
       };
     }
 
-    // Initialize
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', initPopup, { once: true });
+    // Defer initialization until the browser is idle so the popup's setup
+    // work (and its JS chunk) stays out of the LCP critical chain.
+    function scheduleInit() {
+      type IdleWindow = Window & {
+        requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number;
+      };
+      const w = window as IdleWindow;
+      if (typeof w.requestIdleCallback === 'function') {
+        w.requestIdleCallback(initPopup, { timeout: 2000 });
+      } else {
+        setTimeout(initPopup, 1500);
+      }
+    }
+
+    if (document.readyState === 'complete') {
+      scheduleInit();
     } else {
-      initPopup();
+      window.addEventListener('load', scheduleInit, { once: true });
     }
 
     // Re-init on Astro view transitions

--- a/apps/landing-page/src/components/TiledHeader.astro
+++ b/apps/landing-page/src/components/TiledHeader.astro
@@ -19,6 +19,7 @@ const { height = 'h-40' } = Astro.props;
     formats={['webp']}
     widths={[640, 960, 1200, 1600]}
     sizes="100vw"
+    quality={70}
     alt=""
     width={1200}
     height={400}

--- a/apps/landing-page/src/components/events/EventsGrid.tsx
+++ b/apps/landing-page/src/components/events/EventsGrid.tsx
@@ -1,10 +1,11 @@
 // Date-grouped schedule view for the events page
 // Listens for date filter events from the Astro EventDateFilter component
 
-import { useCallback, useEffect, useState } from 'react';
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useEvents } from '@/hooks/useEvents';
 import type { EventItem } from '@/lib/types';
-import EventDetailModal from './EventDetailModal';
+
+const EventDetailModal = lazy(() => import('./EventDetailModal'));
 
 interface EventsGridProps {
   fallback?: EventItem[];
@@ -388,10 +389,52 @@ function filterEventsByDateRange(events: EventItem[], filter: FilterType): Event
 
 // -- Main component ----------------------------------------------------------
 
+function computeAvailableFilters(events: EventItem[]): FilterType[] {
+  const now = new Date();
+  now.setHours(0, 0, 0, 0);
+  const nowMs = now.getTime();
+
+  const weekEnd = new Date(now);
+  weekEnd.setDate(now.getDate() + (7 - now.getDay()));
+  weekEnd.setHours(23, 59, 59, 999);
+  const weekEndMs = weekEnd.getTime();
+
+  const monthEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0);
+  monthEnd.setHours(23, 59, 59, 999);
+  const monthEndMs = monthEnd.getTime();
+
+  const thirtyEnd = new Date(now);
+  thirtyEnd.setDate(now.getDate() + 30);
+  thirtyEnd.setHours(23, 59, 59, 999);
+  const thirtyEndMs = thirtyEnd.getTime();
+
+  let hasWeek = false;
+  let hasMonth = false;
+  let hasThirty = false;
+
+  for (const event of events) {
+    if (!event.isoDate) continue;
+    const t = new Date(event.isoDate).getTime();
+    if (!Number.isFinite(t) || t < nowMs) continue;
+    if (!hasWeek && t <= weekEndMs) hasWeek = true;
+    if (!hasMonth && t <= monthEndMs) hasMonth = true;
+    if (!hasThirty && t <= thirtyEndMs) hasThirty = true;
+    if (hasWeek && hasMonth && hasThirty) break;
+  }
+
+  const available: FilterType[] = [];
+  if (hasWeek) available.push('week');
+  if (hasMonth) available.push('month');
+  if (hasThirty) available.push('30days');
+  available.push('all');
+  return available;
+}
+
 export default function EventsGrid({ fallback = [] }: EventsGridProps) {
-  const { events, loading } = useEvents(fallback);
+  const { events, loading, loadingMore, hasMore, loadAll } = useEvents(fallback);
   const [filter, setFilter] = useState<FilterType>('all');
   const [selectedEvent, setSelectedEvent] = useState<EventItem | null>(null);
+  const loadedAllRef = useRef(false);
 
   // Remove server-rendered skeleton once React has hydrated
   useEffect(() => {
@@ -446,8 +489,23 @@ export default function EventsGrid({ fallback = [] }: EventsGridProps) {
     }
   }, [loading, events, fallback]);
 
+  // When the user picks "all" and the server has more, fetch the rest once.
+  useEffect(() => {
+    if (filter !== 'all') return;
+    if (!hasMore) return;
+    if (loadedAllRef.current) return;
+    loadedAllRef.current = true;
+    loadAll();
+  }, [filter, hasMore, loadAll]);
+
   const displayEvents = events.length > 0 ? events : fallback;
-  const filteredEvents = filterEventsByDateRange(displayEvents, filter);
+
+  const filteredEvents = useMemo(
+    () => filterEventsByDateRange(displayEvents, filter),
+    [displayEvents, filter]
+  );
+  const grouped = useMemo(() => groupEventsByDate(filteredEvents), [filteredEvents]);
+
   const visibleCount = filteredEvents.length;
   const totalCount = displayEvents.length;
 
@@ -459,15 +517,18 @@ export default function EventsGrid({ fallback = [] }: EventsGridProps) {
     if (totalCountEl) totalCountEl.textContent = String(totalCount);
   }, [visibleCount, totalCount]);
 
+  const availableFilters = useMemo(
+    () => (loading ? null : computeAvailableFilters(displayEvents)),
+    [loading, displayEvents]
+  );
+
   // Tell the Astro filter component which filters have events
   useEffect(() => {
-    if (loading) return;
-    const filterIds: FilterType[] = ['week', 'month', '30days', 'all'];
-    const available = filterIds.filter(
-      (id) => id === 'all' || filterEventsByDateRange(displayEvents, id).length > 0
+    if (!availableFilters) return;
+    window.dispatchEvent(
+      new CustomEvent('event-filters-available', { detail: { available: availableFilters } })
     );
-    window.dispatchEvent(new CustomEvent('event-filters-available', { detail: { available } }));
-  }, [loading, displayEvents]);
+  }, [availableFilters]);
 
   if (loading) {
     return <ScheduleSkeleton />;
@@ -481,8 +542,6 @@ export default function EventsGrid({ fallback = [] }: EventsGridProps) {
     return <EmptyState onShowAll={handleShowAll} />;
   }
 
-  const grouped = groupEventsByDate(filteredEvents);
-
   return (
     <>
       <div className="space-y-2">
@@ -495,11 +554,26 @@ export default function EventsGrid({ fallback = [] }: EventsGridProps) {
           />
         ))}
       </div>
-      <EventDetailModal
-        event={selectedEvent}
-        isOpen={!!selectedEvent}
-        onClose={() => setSelectedEvent(null)}
-      />
+      {loadingMore && (
+        <div
+          role="status"
+          aria-label="Loading more sessions"
+          className="flex items-center gap-4 py-3 px-4 mt-2 animate-pulse"
+        >
+          <div className="h-4 w-36 bg-current/10 rounded" />
+          <div className="flex-1" />
+          <div className="h-4 w-32 bg-current/10 rounded" />
+          <div className="h-4 w-20 bg-current/10 rounded" />
+          <div className="h-7 w-24 bg-current/10 rounded-full" />
+        </div>
+      )}
+      <Suspense fallback={null}>
+        <EventDetailModal
+          event={selectedEvent}
+          isOpen={!!selectedEvent}
+          onClose={() => setSelectedEvent(null)}
+        />
+      </Suspense>
     </>
   );
 }

--- a/apps/landing-page/src/hooks/useEvents.ts
+++ b/apps/landing-page/src/hooks/useEvents.ts
@@ -10,30 +10,40 @@ const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 interface CacheEntry {
   events: EventItem[];
   timestamp: number;
+  hasMore: boolean;
 }
 
 interface UseEventsResult {
   events: EventItem[];
   loading: boolean;
+  loadingMore: boolean;
   error: string | null;
+  hasMore: boolean;
   refetch: () => Promise<void>;
+  loadAll: () => Promise<void>;
 }
 
-function getCachedEvents(): EventItem[] | null {
+function readCache(): CacheEntry | null {
   if (typeof window === 'undefined') return null;
 
   try {
     const cached = sessionStorage.getItem(CACHE_KEY);
     if (!cached) return null;
 
-    const entry: CacheEntry = JSON.parse(cached);
+    const entry = JSON.parse(cached) as Partial<CacheEntry>;
+    if (!entry || !Array.isArray(entry.events) || typeof entry.timestamp !== 'number') {
+      return null;
+    }
     const age = Date.now() - entry.timestamp;
 
     if (age < CACHE_TTL_MS) {
-      return entry.events;
+      return {
+        events: entry.events,
+        timestamp: entry.timestamp,
+        hasMore: !!entry.hasMore,
+      };
     }
 
-    // Cache expired, remove it
     sessionStorage.removeItem(CACHE_KEY);
     return null;
   } catch {
@@ -41,13 +51,14 @@ function getCachedEvents(): EventItem[] | null {
   }
 }
 
-function setCachedEvents(events: EventItem[]): void {
+function writeCache(events: EventItem[], hasMore: boolean): void {
   if (typeof window === 'undefined') return;
 
   try {
     const entry: CacheEntry = {
       events,
       timestamp: Date.now(),
+      hasMore,
     };
     sessionStorage.setItem(CACHE_KEY, JSON.stringify(entry));
   } catch {
@@ -58,13 +69,15 @@ function setCachedEvents(events: EventItem[]): void {
 export function useEvents(fallbackEvents: EventItem[] = []): UseEventsResult {
   const [events, setEvents] = useState<EventItem[]>(fallbackEvents);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(false);
 
   const fetchEvents = useCallback(async () => {
-    // Check cache first
-    const cached = getCachedEvents();
+    const cached = readCache();
     if (cached) {
-      setEvents(cached);
+      setEvents(cached.events);
+      setHasMore(cached.hasMore);
       setLoading(false);
       return;
     }
@@ -80,14 +93,15 @@ export function useEvents(fallbackEvents: EventItem[] = []): UseEventsResult {
       }
 
       const data = await response.json();
-      const fetchedEvents = data.events || [];
+      const fetchedEvents: EventItem[] = data.events || [];
+      const fetchedHasMore = !!data.hasMore;
 
-      setCachedEvents(fetchedEvents);
+      writeCache(fetchedEvents, fetchedHasMore);
       setEvents(fetchedEvents);
+      setHasMore(fetchedHasMore);
     } catch (err) {
       console.error('[useEvents] Fetch error:', err);
       setError(err instanceof Error ? err.message : 'Failed to fetch events');
-      // Use fallback events on error (only if we have them)
       if (fallbackEvents.length > 0) {
         setEvents(fallbackEvents);
       }
@@ -97,16 +111,38 @@ export function useEvents(fallbackEvents: EventItem[] = []): UseEventsResult {
   }, [fallbackEvents]);
 
   const refetch = useCallback(async () => {
-    // Clear cache before refetching
     if (typeof window !== 'undefined') {
       sessionStorage.removeItem(CACHE_KEY);
     }
     await fetchEvents();
   }, [fetchEvents]);
 
+  const loadAll = useCallback(async () => {
+    setLoadingMore(true);
+    try {
+      const response = await fetch('/api/events?all=1');
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const data = await response.json();
+      const fetchedEvents: EventItem[] = data.events || [];
+
+      writeCache(fetchedEvents, false);
+      setEvents(fetchedEvents);
+      setHasMore(false);
+    } catch (err) {
+      console.error('[useEvents] loadAll error:', err);
+      setError(err instanceof Error ? err.message : 'Failed to fetch events');
+    } finally {
+      setLoadingMore(false);
+    }
+  }, []);
+
   useEffect(() => {
     fetchEvents();
   }, [fetchEvents]);
 
-  return { events, loading, error, refetch };
+  return { events, loading, loadingMore, error, hasMore, refetch, loadAll };
 }

--- a/apps/landing-page/src/layouts/main.astro
+++ b/apps/landing-page/src/layouts/main.astro
@@ -1,12 +1,8 @@
 ---
 import '../styles/global.css';
 
-// Import critical below-fold images for preloading
-import { getImage } from 'astro:assets';
 import fontRegularWoff2 from '../assets/fonts/PPNeueMontreal-Regular.woff2';
 import fontSemiBoldWoff2 from '../assets/fonts/PPNeueMontreal-SemiBold.woff2';
-import plungingImg from '../assets/images/plunging.webp';
-import warmSaunaImg from '../assets/images/warm_sauna.webp';
 import faviconSvg from '../assets/logos/pyre_logo.svg?raw';
 import AnnouncementBanner from '../components/AnnouncementBanner.astro';
 import Footer from '../components/Footer.astro';
@@ -24,10 +20,6 @@ import {
   SOCIAL_IMAGE_WIDTH,
   TWITTER_HANDLE,
 } from '../lib/seo';
-
-// Generate optimized image URLs for preloading
-const warmSaunaOptimized = await getImage({ src: warmSaunaImg, width: 800 });
-const plungingOptimized = await getImage({ src: plungingImg, width: 600 });
 
 interface Props {
   title?: string;
@@ -274,14 +266,6 @@ const llmsTxtUrl = Astro.site ? new URL('/llms.txt', Astro.site).toString() : '/
 		)}
 		<link rel="preload" as="font" href={fontRegularWoff2} type="font/woff2" crossorigin />
 		<link rel="preload" as="font" href={fontSemiBoldWoff2} type="font/woff2" crossorigin />
-
-		<!-- Preload critical below-fold images to prevent late loading -->
-		{isHomePage && (
-			<>
-				<link rel="preload" as="image" href={warmSaunaOptimized.src} />
-				<link rel="preload" as="image" href={plungingOptimized.src} />
-			</>
-		)}
 
 		{import.meta.env.PROD && <PostHog />}
 		<script>

--- a/apps/landing-page/src/pages/api/events.ts
+++ b/apps/landing-page/src/pages/api/events.ts
@@ -19,6 +19,19 @@ interface EventsApiResponse {
   events: EventItem[];
   cached: boolean;
   timestamp: string;
+  hasMore: boolean;
+  totalUpcoming: number;
+}
+
+const DEFAULT_WINDOW_DAYS = 60;
+const MIN_WINDOW_DAYS = 1;
+const MAX_WINDOW_DAYS = 730;
+
+function parseWindowDays(raw: string | null): number {
+  if (!raw) return DEFAULT_WINDOW_DAYS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) return DEFAULT_WINDOW_DAYS;
+  return Math.min(MAX_WINDOW_DAYS, Math.max(MIN_WINDOW_DAYS, parsed));
 }
 
 async function fetchMomenceEventsServer(): Promise<MomenceEvent[]> {
@@ -57,18 +70,49 @@ async function fetchMomenceEventsServer(): Promise<MomenceEvent[]> {
   return [];
 }
 
-export const GET: APIRoute = async () => {
+export const GET: APIRoute = async ({ url }) => {
   try {
+    const wantsAll = url.searchParams.get('all') === '1';
+    const windowDays = parseWindowDays(url.searchParams.get('days'));
+
     const rawEvents = await fetchMomenceEventsServer();
     const validEvents = filterValidEvents(rawEvents);
     const nonVolunteerEvents = excludeVolunteerEvents(validEvents);
     const sortedEvents = sortEventsByDate(nonVolunteerEvents);
-    const events = sortedEvents.map(transformToEventItem);
+    const allEvents = sortedEvents.map(transformToEventItem);
+
+    let events: EventItem[];
+    let hasMore: boolean;
+
+    if (wantsAll) {
+      events = allEvents;
+      hasMore = false;
+    } else {
+      const cutoff = Date.now() + windowDays * 24 * 60 * 60 * 1000;
+      const eventsInWindow: EventItem[] = [];
+      let restCount = 0;
+      for (const event of allEvents) {
+        if (!event.isoDate) {
+          eventsInWindow.push(event);
+          continue;
+        }
+        const eventTime = new Date(event.isoDate).getTime();
+        if (Number.isFinite(eventTime) && eventTime > cutoff) {
+          restCount += 1;
+        } else {
+          eventsInWindow.push(event);
+        }
+      }
+      events = eventsInWindow;
+      hasMore = restCount > 0;
+    }
 
     const response: EventsApiResponse = {
       events,
       cached: false,
       timestamp: new Date().toISOString(),
+      hasMore,
+      totalUpcoming: allEvents.length,
     };
 
     return new Response(JSON.stringify(response), {
@@ -87,6 +131,8 @@ export const GET: APIRoute = async () => {
         events: [],
         cached: false,
         timestamp: new Date().toISOString(),
+        hasMore: false,
+        totalUpcoming: 0,
         error: 'Failed to fetch events',
       }),
       {

--- a/apps/landing-page/src/pages/events/index.astro
+++ b/apps/landing-page/src/pages/events/index.astro
@@ -54,7 +54,7 @@ const description =
             </div>
           ))}
         </div>
-        <EventsGrid client:load fallback={fallbackEvents.items} />
+        <EventsGrid client:idle fallback={fallbackEvents.items} />
       </div>
 
       <!-- Results Count -->

--- a/apps/landing-page/src/styles/global.css
+++ b/apps/landing-page/src/styles/global.css
@@ -22,7 +22,7 @@
 
   font-weight: 400;
   font-style: normal;
-  font-display: swap;
+  font-display: optional;
 }
 
 @font-face {
@@ -52,7 +52,7 @@
     url("../assets/fonts/PPFraktionMono-Bold.woff") format("woff");
   font-weight: 700;
   font-style: normal;
-  font-display: swap;
+  font-display: optional;
 }
 
 @theme inline {


### PR DESCRIPTION
- /api/events now returns a 60-day default window with hasMore + ?all=1
  opt-in; useEvents exposes loadAll and the EventsGrid triggers it once
  when the user picks "All Upcoming".
- Defer EventsGrid hydration to client:idle so initial INP isn't blocked
  by parsing/hydrating the 500-line component above the server skeleton.
- Code-split EventDetailModal via React.lazy + Suspense — its chunk only
  loads after the user clicks a row.
- Memoize filteredEvents/grouped and collapse the 3x available-filters
  pass into a single iteration.
- Right-size AboutSection's warm_sauna.webp with <Picture> widths/sizes,
  drop the contradictory homepage image preloads (image is lazy/below
  fold), and lower HeroCarousel/TiledHeader webp quality to 70.
- Switch Eckmannpsych-Small and PPFraktionMono-Bold to font-display:
  optional so they're not in the LCP critical chain.
- Defer PromoPopup initialization to requestIdleCallback so its script
  drops out of the LCP critical request chain.