### PR TITLE
fix(landing-page): make events loading skeleton visible

### DIFF
--- a/apps/landing-page/src/components/events/EventsGrid.tsx
+++ b/apps/landing-page/src/components/events/EventsGrid.tsx
@@ -74,7 +74,7 @@ function ArrowIcon() {
 
 function ScheduleSkeleton() {
   return (
-    <div className="space-y-8">
+    <div className="space-y-8 text-[var(--pyre-creme)]">
       {Array.from({ length: 3 }).map((_, gi) => (
         <div key={`skel-group-${gi}`}>
           {/* Date header shimmer */}
@@ -558,7 +558,7 @@ export default function EventsGrid({ fallback = [] }: EventsGridProps) {
         <div
           role="status"
           aria-label="Loading more sessions"
-          className="flex items-center gap-4 py-3 px-4 mt-2 animate-pulse"
+          className="flex items-center gap-4 py-3 px-4 mt-2 animate-pulse text-[var(--pyre-creme)]"
         >
           <div className="h-4 w-36 bg-current/10 rounded" />
           <div className="flex-1" />


### PR DESCRIPTION
The React ScheduleSkeleton wrapper inherited body's text-foreground
(--pyre-black), so bg-current/10 rendered as 10% black on the black
page background — invisible. The server-rendered #events-skeleton in
events/index.astro looked fine because it set text-[var(--pyre-creme)]
explicitly, but React removed that on hydration and replaced it with
its own untinted skeleton. Set text-[var(--pyre-creme)] on the React
skeleton wrappers (both initial and load-more) so the shimmer bars
show during /api/events fetches.