### PR TITLE
Fix homepage animation performance and event states

### DIFF
--- a/apps/landing-page/src/components/EventsSection.astro
+++ b/apps/landing-page/src/components/EventsSection.astro
@@ -100,6 +100,33 @@ const isCompact = variant === 'compact';
         </div>
       </div>
 
+      <div class="hidden" data-events-error>
+        <div class="flex justify-center">
+          <div class="flex flex-col items-center justify-center text-center py-12 px-6 w-[280px] md:w-[320px] bg-[var(--background)] border border-current/20 rounded-lg">
+            <svg
+              class="w-12 h-12 mb-4 opacity-40"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.5"
+                d="M12 9v4m0 4h.01M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"
+              />
+            </svg>
+            <p class="font-mono-bold text-lg uppercase tracking-wide mb-3 opacity-70">
+              Events could not load
+            </p>
+            <p class="text-sm opacity-70">
+              Please refresh or view the full schedule.
+            </p>
+          </div>
+        </div>
+      </div>
+
       <div class="events-container -mx-4 px-4 md:-mx-8 md:px-8" data-events-list hidden></div>
     </div>
 
@@ -242,14 +269,17 @@ const isCompact = variant === 'compact';
       const limit = Number.parseInt(section.dataset.eventsLimit || '10', 10) || 10;
       const loading = section.querySelector<HTMLElement>('[data-events-loading]');
       const empty = section.querySelector<HTMLElement>('[data-events-empty]');
+      const error = section.querySelector<HTMLElement>('[data-events-error]');
       const list = section.querySelector<HTMLElement>('[data-events-list]');
       if (!list) return;
 
       loading?.classList.remove('hidden');
       empty?.classList.add('hidden');
+      error?.classList.add('hidden');
       list.hidden = true;
 
       let events = readCache(limit);
+      let fetchFailed = false;
       if (!events) {
         try {
           const response = await fetch(`/api/events?limit=${limit}`);
@@ -258,11 +288,17 @@ const isCompact = variant === 'compact';
           events = Array.isArray(data.events) ? data.events : [];
           writeCache(limit, events);
         } catch {
+          fetchFailed = true;
           events = [];
         }
       }
 
       loading?.classList.add('hidden');
+      if (fetchFailed) {
+        error?.classList.remove('hidden');
+        return;
+      }
+
       if (!events.length) {
         empty?.classList.remove('hidden');
         return;

--- a/apps/landing-page/src/components/SignupForm.astro
+++ b/apps/landing-page/src/components/SignupForm.astro
@@ -220,11 +220,38 @@ const turnstileTheme = isCompact ? 'dark' : 'auto';
       }
       if (turnstileScriptPromise) return turnstileScriptPromise;
 
-      turnstileScriptPromise = new Promise((resolve, reject) => {
+      turnstileScriptPromise = new Promise<void>((resolve, reject) => {
         const existing = document.querySelector<HTMLScriptElement>('script[data-turnstile-loader]');
         if (existing) {
-          existing.addEventListener('load', () => resolve(), { once: true });
-          existing.addEventListener('error', () => reject(new Error('Turnstile failed to load')), { once: true });
+          if (typeof (window as any).turnstile !== 'undefined') {
+            resolve();
+            return;
+          }
+          if (existing.dataset.turnstileLoaded === 'true') {
+            reject(new Error('Turnstile loaded but unavailable'));
+            return;
+          }
+          if (existing.dataset.turnstileError === 'true') {
+            reject(new Error('Turnstile failed to load'));
+            return;
+          }
+          const existingState = existing as HTMLScriptElement & { complete?: boolean; readyState?: string };
+          if (existingState.complete || existingState.readyState === 'complete') {
+            reject(new Error('Turnstile loaded but unavailable'));
+            return;
+          }
+          existing.addEventListener('load', () => {
+            existing.dataset.turnstileLoaded = 'true';
+            if (typeof (window as any).turnstile !== 'undefined') {
+              resolve();
+            } else {
+              reject(new Error('Turnstile loaded but unavailable'));
+            }
+          }, { once: true });
+          existing.addEventListener('error', () => {
+            existing.dataset.turnstileError = 'true';
+            reject(new Error('Turnstile failed to load'));
+          }, { once: true });
           return;
         }
 
@@ -233,9 +260,22 @@ const turnstileTheme = isCompact ? 'dark' : 'auto';
         script.async = true;
         script.defer = true;
         script.dataset.turnstileLoader = 'true';
-        script.addEventListener('load', () => resolve(), { once: true });
-        script.addEventListener('error', () => reject(new Error('Turnstile failed to load')), { once: true });
+        script.addEventListener('load', () => {
+          script.dataset.turnstileLoaded = 'true';
+          if (typeof (window as any).turnstile !== 'undefined') {
+            resolve();
+          } else {
+            reject(new Error('Turnstile loaded but unavailable'));
+          }
+        }, { once: true });
+        script.addEventListener('error', () => {
+          script.dataset.turnstileError = 'true';
+          reject(new Error('Turnstile failed to load'));
+        }, { once: true });
         document.head.appendChild(script);
+      }).catch((error) => {
+        turnstileScriptPromise = null;
+        throw error;
       });
 
       return turnstileScriptPromise;

--- a/apps/landing-page/src/components/TestimonialsSection.astro
+++ b/apps/landing-page/src/components/TestimonialsSection.astro
@@ -53,7 +53,7 @@ for (let index = 0; index < maxEntries; index += 1) {
             entry.kind === 'testimonial' ? (
               <article
                 class:list={[
-                  'testimonial-card flex-shrink-0 w-[280px] md:w-[300px] aspect-[4/5] snap-start rounded-lg overflow-hidden p-6 flex flex-col transition-all duration-300',
+                  'testimonial-card flex-shrink-0 w-[280px] md:w-[300px] min-h-[430px] md:min-h-0 md:aspect-[4/5] snap-start rounded-lg overflow-hidden p-6 flex flex-col transition-all duration-300',
                   entry.item.highlight
                     ? 'border border-[var(--pyre-gold)] bg-[var(--pyre-gold)]/5'
                     : 'border border-current/10',
@@ -69,7 +69,7 @@ for (let index = 0; index < maxEntries; index += 1) {
                     </svg>
                   ))}
                 </div>
-                <blockquote class="mb-4 flex-1 overflow-hidden">
+                <blockquote class="mb-4 flex-1">
                   <p class="italic leading-relaxed opacity-90">"{entry.item.quote}"</p>
                 </blockquote>
                 <footer>
@@ -84,7 +84,7 @@ for (let index = 0; index < maxEntries; index += 1) {
                 </footer>
               </article>
             ) : (
-              <div class="testimonial-photo flex-shrink-0 w-[280px] md:w-[300px] aspect-[4/5] snap-start rounded-lg overflow-hidden border border-current/10">
+              <div class="testimonial-photo flex-shrink-0 w-[280px] md:w-[300px] h-[430px] md:h-auto md:aspect-[4/5] snap-start rounded-lg overflow-hidden border border-current/10">
                 <img
                   src={entry.item.src}
                   alt={entry.item.alt}

--- a/apps/landing-page/src/pages/api/events.ts
+++ b/apps/landing-page/src/pages/api/events.ts
@@ -43,6 +43,28 @@ function parseLimit(raw: string | null): number | null {
   return Math.min(MAX_LIMIT, Math.max(MIN_LIMIT, parsed));
 }
 
+function filterEventsByWindow(events: EventItem[], windowDays: number): { eventsInWindow: EventItem[]; outsideWindowCount: number } {
+  const cutoff = Date.now() + windowDays * 24 * 60 * 60 * 1000;
+  const eventsInWindow: EventItem[] = [];
+  let outsideWindowCount = 0;
+
+  for (const event of events) {
+    if (!event.isoDate) {
+      eventsInWindow.push(event);
+      continue;
+    }
+
+    const eventTime = new Date(event.isoDate).getTime();
+    if (Number.isFinite(eventTime) && eventTime > cutoff) {
+      outsideWindowCount += 1;
+    } else {
+      eventsInWindow.push(event);
+    }
+  }
+
+  return { eventsInWindow, outsideWindowCount };
+}
+
 async function fetchMomenceEventsServer(): Promise<MomenceEvent[]> {
   const hostId = import.meta.env.MOMENCE_HOST_ID;
   const apiToken = import.meta.env.MOMENCE_API_TOKEN;
@@ -82,7 +104,8 @@ async function fetchMomenceEventsServer(): Promise<MomenceEvent[]> {
 export const GET: APIRoute = async ({ url }) => {
   try {
     const wantsAll = url.searchParams.get('all') === '1';
-    const windowDays = parseWindowDays(url.searchParams.get('days'));
+    const daysParam = url.searchParams.get('days');
+    const windowDays = parseWindowDays(daysParam);
     const limit = parseLimit(url.searchParams.get('limit'));
 
     const rawEvents = await fetchMomenceEventsServer();
@@ -94,30 +117,19 @@ export const GET: APIRoute = async ({ url }) => {
     let events: EventItem[];
     let hasMore: boolean;
 
-    if (limit !== null && !wantsAll) {
-      events = allEvents.slice(0, limit);
-      hasMore = allEvents.length > limit;
-    } else if (wantsAll) {
+    if (wantsAll) {
       events = allEvents;
       hasMore = false;
+    } else if (limit !== null) {
+      const candidateEvents = daysParam === null
+        ? allEvents
+        : filterEventsByWindow(allEvents, windowDays).eventsInWindow;
+      events = candidateEvents.slice(0, limit);
+      hasMore = candidateEvents.length > limit;
     } else {
-      const cutoff = Date.now() + windowDays * 24 * 60 * 60 * 1000;
-      const eventsInWindow: EventItem[] = [];
-      let restCount = 0;
-      for (const event of allEvents) {
-        if (!event.isoDate) {
-          eventsInWindow.push(event);
-          continue;
-        }
-        const eventTime = new Date(event.isoDate).getTime();
-        if (Number.isFinite(eventTime) && eventTime > cutoff) {
-          restCount += 1;
-        } else {
-          eventsInWindow.push(event);
-        }
-      }
+      const { eventsInWindow, outsideWindowCount } = filterEventsByWindow(allEvents, windowDays);
       events = eventsInWindow;
-      hasMore = restCount > 0;
+      hasMore = outsideWindowCount > 0;
     }
 
     const response: EventsApiResponse = {

--- a/apps/landing-page/src/pages/index.astro
+++ b/apps/landing-page/src/pages/index.astro
@@ -52,7 +52,7 @@ import { heroGrainGradient } from '../lib/shader-configs';
     </div>
 
     <div class="relative z-20 px-4 pt-4 pb-4 lg:z-10 lg:ml-[40%] lg:w-[60%] lg:pt-[100vh] lg:px-6 lg:pb-6 gpu-layer">
-      <div class="home-card home-card--animated" data-section="about">
+      <div class="home-card home-card--animated card-cta-animated" data-section="about">
         <AboutSection />
       </div>
 
@@ -60,7 +60,7 @@ import { heroGrainGradient } from '../lib/shader-configs';
         <ExperiencesSection />
       </div>
 
-      <div class="home-card home-card--animated home-card--deferred home-card--md" data-section="events">
+      <div class="home-card home-card--animated card-cta-animated home-card--deferred home-card--md" data-section="events">
         <EventsSection limit={10} />
       </div>
 
@@ -80,7 +80,7 @@ import { heroGrainGradient } from '../lib/shader-configs';
         <MembershipSection />
       </div>
 
-      <div class="home-card home-card--animated home-card--deferred home-card--sm" data-section="group-booking">
+      <div class="home-card home-card--animated card-cta-animated home-card--deferred home-card--sm" data-section="group-booking">
         <GroupBookingSection />
       </div>
 
@@ -92,7 +92,7 @@ import { heroGrainGradient } from '../lib/shader-configs';
         <FAQAccordion />
       </div>
 
-      <div id="signup" class="home-card home-card--animated home-card--deferred home-card--md" data-section="signup">
+      <div id="signup" class="home-card home-card--animated card-cta-animated home-card--deferred home-card--md" data-section="signup">
         <SignupForm />
       </div>
     </div>
@@ -250,22 +250,44 @@ import { heroGrainGradient } from '../lib/shader-configs';
     }
   }
 
-  function initAnimationPausing() {
-    if (window.innerWidth < 1024) return;
+  let animationCleanup: (() => void) | null = null;
 
-    const animatedEls = document.querySelectorAll('.btn-cta-animated, .card-cta-animated');
+  function initAnimationPausing() {
+    if (animationCleanup) {
+      animationCleanup();
+      animationCleanup = null;
+    }
+
+    const canAnimate = window.matchMedia('(min-width: 1024px) and (prefers-reduced-motion: no-preference)').matches;
+    if (!canAnimate) return;
+
+    const animatedEls = document.querySelectorAll<HTMLElement>('.btn-cta-animated, .card-cta-animated');
     if (animatedEls.length === 0) return;
 
     const observer = new IntersectionObserver(
       (entries) => {
+        if (document.hidden) return;
         for (const entry of entries) {
           entry.target.classList.toggle('is-animating', entry.isIntersecting);
         }
       },
-      { rootMargin: '100px 0px' }
+      { rootMargin: '0px', threshold: 0 }
     );
 
     animatedEls.forEach((el) => observer.observe(el));
+
+    const pauseWhenHidden = () => {
+      if (!document.hidden) return;
+      animatedEls.forEach((el) => el.classList.remove('is-animating'));
+    };
+
+    document.addEventListener('visibilitychange', pauseWhenHidden);
+
+    animationCleanup = () => {
+      observer.disconnect();
+      document.removeEventListener('visibilitychange', pauseWhenHidden);
+      animatedEls.forEach((el) => el.classList.remove('is-animating'));
+    };
   }
 
   if (document.readyState === 'loading') {
@@ -275,4 +297,6 @@ import { heroGrainGradient } from '../lib/shader-configs';
     initSmoothScroll();
     initAnimationPausing();
   }
+
+  document.addEventListener('astro:page-load', initAnimationPausing);
 </script>

--- a/apps/landing-page/src/styles/global.css
+++ b/apps/landing-page/src/styles/global.css
@@ -377,8 +377,6 @@
   background: var(--pyre-black);
 }
 
-/* Only apply animation on lg+ screens where rounded corners are visible */
-/* @media (min-width: 1024px) { */
 .card-cta-animated::before {
   content: "";
   position: absolute;
@@ -409,7 +407,6 @@
   background: var(--pyre-black);
   border-radius: calc(0.5rem - 4px);
 }
-/* } */
 
 /* Accessibility: Respect reduced motion for card animation */
 @media (prefers-reduced-motion: reduce) {
@@ -418,14 +415,11 @@
   }
 }
 
-/* Mobile performance: freeze the rotating conic-gradient on CTAs and
-   cards. Animating @property --gradient-angle re-rasterizes the entire
-   conic-gradient every frame, which keeps the navbar Book button and
-   every animated card constantly repainting. The static gradient border
-   still shows; it just doesn't rotate. */
+/* Mobile performance: keep card gradients painted but paused by default.
+   Buttons are simpler to flatten on mobile because they don't need the
+   static border treatment. */
 @media (max-width: 1023px) {
-  .btn-cta-animated::before,
-  .card-cta-animated::before {
+  .btn-cta-animated::before {
     animation: none;
   }
 }


### PR DESCRIPTION
## Summary
- animate selected homepage cards only while visible on desktop while keeping mobile card borders static
- harden Turnstile script loading and event limit/date-window behavior
- add a distinct events fetch-error state and prevent mobile testimonial clipping

## Verification
- yarn biome lint src/pages/index.astro src/styles/global.css src/components/SignupForm.astro src/pages/api/events.ts src/components/EventsSection.astro
- yarn biome lint src/components/TestimonialsSection.astro
- yarn build
- browser-checked desktop/mobile card animation behavior and mobile testimonial sizing
- smoke-checked /api/events, /api/events?limit=10, /api/events?days=60&limit=10, and /api/events?all=1