### PR TITLE
Remove SectionBridge component and simplify section transitions

### DIFF
--- a/apps/landing-page/src/pages/index.astro
+++ b/apps/landing-page/src/pages/index.astro
@@ -13,7 +13,6 @@ import HeroBackground from '../components/HeroBackground.astro';
 import HeroCarousel from '../components/HeroCarousel.astro';
 import MembershipSection from '../components/MembershipSection.astro';
 import ShaderCanvas from '../components/ShaderCanvas.astro';
-import SectionBridge from '../components/SectionBridge.astro';
 import SessionSection from '../components/SessionSection.astro';
 import SignupForm from '../components/SignupForm.astro';
 import TestimonialsSection from '../components/TestimonialsSection.astro';
@@ -71,14 +70,11 @@ import { heroGrainGradient } from '../lib/shader-configs';
         </div>
       </div>
 
-      <div class="home-card home-card--joined-top home-card--deferred home-card--md" data-section="sessions">
+      <div class="home-card home-card--deferred home-card--md" data-section="sessions">
         <SessionSection />
       </div>
-      <div class="bg-[var(--pyre-black)]">
-        <SectionBridge bgColor="var(--pyre-black)" variant="wave" position="bottom" height="sm" />
-        <SectionBridge bgColor="var(--pyre-black)" variant="wave" position="top" height="sm" />
-      </div>
-      <div class="home-card home-card--joined-bottom home-card--deferred home-card--lg" data-section="membership">
+
+      <div class="home-card home-card--deferred home-card--lg" data-section="membership">
         <MembershipSection />
       </div>
 


### PR DESCRIPTION
## Summary
Removes the `SectionBridge` component and its associated wave dividers between the Sessions and Membership sections, simplifying the layout by eliminating the decorative transition elements and their styling classes.

## Changes
- Removed `SectionBridge` component import from the landing page
- Deleted the wave divider markup that created visual transitions between sections
- Removed `home-card--joined-top` and `home-card--joined-bottom` CSS classes from SessionSection and MembershipSection containers
- Removed the intermediate `bg-[var(--pyre-black)]` wrapper div that housed the bridge components
- Added a simple blank line between the two sections for cleaner spacing

## Implementation Details
The SectionBridge component was providing decorative wave SVG dividers with top and bottom positioning. By removing this, the sections now have a simpler, more direct visual relationship. The related CSS classes (`home-card--joined-top` and `home-card--joined-bottom`) that were likely used to adjust spacing around the bridge elements have also been removed, as they're no longer needed.

https://claude.ai/code/session_01X6TufUz9oJdVLQ5HDw4H3d