### PR TITLE
Improve events modal and list styling

### DIFF
--- a/apps/landing-page/src/components/events/EventDetailModal.tsx
+++ b/apps/landing-page/src/components/events/EventDetailModal.tsx
@@ -203,7 +203,7 @@ export default function EventDetailModal({ event, isOpen, onClose }: EventDetail
           type="button"
           onClick={onClose}
           aria-label="Close details"
-          className="absolute top-3 right-3 z-30 rounded-full bg-black/40 backdrop-blur-sm p-1.5 text-[var(--pyre-creme)] hover:bg-black/60 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pyre-gold)]/50"
+          className="absolute top-3 right-3 z-30 rounded-full border border-[var(--pyre-gold)]/70 bg-black/40 backdrop-blur-sm p-1.5 text-[var(--pyre-creme)] hover:bg-black/60 hover:border-[var(--pyre-gold)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pyre-gold)]/50"
         >
           <svg
             className="size-5"

--- a/apps/landing-page/src/components/events/EventDetailModal.tsx
+++ b/apps/landing-page/src/components/events/EventDetailModal.tsx
@@ -195,7 +195,7 @@ export default function EventDetailModal({ event, isOpen, onClose }: EventDetail
       {/* Panel */}
       <div
         ref={panelRef}
-        className="relative z-10 w-full max-w-lg max-h-[90vh] overflow-y-auto rounded-lg border border-[var(--pyre-creme)]/10 bg-[var(--pyre-black)] shadow-2xl"
+        className="relative z-10 flex flex-col w-full max-w-lg max-h-[90vh] overflow-hidden rounded-lg border border-[var(--pyre-creme)]/10 bg-[var(--pyre-black)] shadow-2xl"
       >
         {/* Close button */}
         <button
@@ -203,7 +203,7 @@ export default function EventDetailModal({ event, isOpen, onClose }: EventDetail
           type="button"
           onClick={onClose}
           aria-label="Close details"
-          className="absolute top-3 right-3 z-20 rounded-md p-1.5 text-[var(--pyre-creme)]/60 hover:text-[var(--pyre-creme)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pyre-gold)]/50"
+          className="absolute top-3 right-3 z-30 rounded-full bg-black/40 backdrop-blur-sm p-1.5 text-[var(--pyre-creme)] hover:bg-black/60 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pyre-gold)]/50"
         >
           <svg
             className="size-5"
@@ -217,78 +217,86 @@ export default function EventDetailModal({ event, isOpen, onClose }: EventDetail
           </svg>
         </button>
 
-        {/* Event image */}
+        {/* Pinned event image (sits behind the scrolling content) */}
         {event.image && (
           <img
             src={event.image.src}
             alt={event.image.alt}
-            className="w-full h-48 sm:h-56 object-cover rounded-t-lg"
+            className="absolute top-0 inset-x-0 w-full h-48 sm:h-56 object-cover"
             loading="lazy"
           />
         )}
 
-        {/* Content */}
-        <div className="px-6 pt-8 pb-6">
-          {/* Title */}
-          <h2
-            id="event-detail-title"
-            className="font-mono-bold text-xl sm:text-2xl uppercase tracking-wide text-[var(--pyre-creme)] pr-8"
-          >
-            {event.title}
-          </h2>
+        {/* Scrollable region — content scrolls up over the pinned image */}
+        <div className="relative z-10 flex-1 overflow-y-auto">
+          {/* Spacer that reveals the pinned image; content card overlaps its lower edge */}
+          {event.image && <div className="h-40 sm:h-48" aria-hidden="true" />}
 
-          {/* Details grid */}
-          <div className="mt-4 space-y-2">
-            {/* Date */}
-            <div className="flex items-center gap-2 text-sm text-[var(--pyre-creme)]/70">
-              <ClockIcon className="w-4 h-4 flex-shrink-0" />
-              <span>{event.date}</span>
-            </div>
+          {/* Content card */}
+          <div className="relative bg-[var(--pyre-black)] rounded-t-2xl px-6 pt-8 pb-6">
+            {/* Title */}
+            <h2
+              id="event-detail-title"
+              className="font-mono-bold text-xl sm:text-2xl uppercase tracking-wide text-[var(--pyre-creme)] pr-8"
+            >
+              {event.title}
+            </h2>
 
-            {/* Time */}
-            <div className="flex items-center gap-2 text-sm text-[var(--pyre-creme)]/70">
-              <ClockIcon className="w-4 h-4 flex-shrink-0" />
-              <span>{event.time}</span>
-            </div>
-
-            {/* Location */}
-            <div className="flex items-center gap-2 text-sm text-[var(--pyre-creme)]/70">
-              <MapPinIcon className="w-4 h-4 flex-shrink-0" />
-              <span>{event.location}</span>
-            </div>
-
-            {/* Spots */}
-            {spots && (
-              <div
-                className={`flex items-center gap-2 text-sm ${spotsColor(event.spotsRemaining)}`}
-              >
-                <UsersIcon className="w-4 h-4 flex-shrink-0" />
-                <span>{spots}</span>
+            {/* Details grid */}
+            <div className="mt-4 space-y-2">
+              {/* Date */}
+              <div className="flex items-center gap-2 text-sm text-[var(--pyre-creme)]/70">
+                <ClockIcon className="w-4 h-4 flex-shrink-0" />
+                <span>{event.date}</span>
               </div>
+
+              {/* Time */}
+              <div className="flex items-center gap-2 text-sm text-[var(--pyre-creme)]/70">
+                <ClockIcon className="w-4 h-4 flex-shrink-0" />
+                <span>{event.time}</span>
+              </div>
+
+              {/* Location */}
+              <div className="flex items-center gap-2 text-sm text-[var(--pyre-creme)]/70">
+                <MapPinIcon className="w-4 h-4 flex-shrink-0" />
+                <span>{event.location}</span>
+              </div>
+
+              {/* Spots */}
+              {spots && (
+                <div
+                  className={`flex items-center gap-2 text-sm ${spotsColor(event.spotsRemaining)}`}
+                >
+                  <UsersIcon className="w-4 h-4 flex-shrink-0" />
+                  <span>{spots}</span>
+                </div>
+              )}
+            </div>
+
+            {/* Description */}
+            {event.description && (
+              <p className="mt-5 whitespace-pre-line font-sans text-base leading-relaxed text-[var(--pyre-creme)]/80">
+                {event.description}
+              </p>
             )}
           </div>
+        </div>
 
-          {/* Description */}
-          {event.description && (
-            <p className="mt-5 whitespace-pre-line font-sans text-base leading-relaxed text-[var(--pyre-creme)]/80">
-              {event.description}
-            </p>
-          )}
-
-          {/* Booking CTA */}
-          {!event.isPrivate && event.cta && (
+        {/* Fixed footer — Book Now CTA stays anchored at the bottom */}
+        {!event.isPrivate && event.cta && (
+          <div className="relative z-20 border-t border-[var(--pyre-creme)]/10 bg-[var(--pyre-black)] px-6 py-4">
             <a
               href={event.cta.href}
               target="_blank"
               rel="noopener noreferrer"
               aria-label={event.cta.ariaLabel ?? `Book ${event.title}`}
-              className="mt-6 flex w-full items-center justify-center gap-2 rounded-full bg-[var(--pyre-red)] px-6 py-3 font-mono-bold text-sm uppercase tracking-wide text-[var(--pyre-creme)] transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pyre-red)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--pyre-black)]"
+              className="flex w-full items-center justify-center gap-2 rounded-full bg-[var(--pyre-red)] px-6 py-3 font-mono-bold text-sm uppercase tracking-wide text-[var(--pyre-creme)] transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pyre-red)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--pyre-black)]"
             >
               {ctaLabel}
               <ArrowIcon />
             </a>
-          )}
-        </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/landing-page/src/components/events/EventDetailModal.tsx
+++ b/apps/landing-page/src/components/events/EventDetailModal.tsx
@@ -229,8 +229,9 @@ export default function EventDetailModal({ event, isOpen, onClose }: EventDetail
 
         {/* Scrollable region — content scrolls up over the pinned image */}
         <div className="relative z-10 flex-1 overflow-y-auto">
-          {/* Spacer that reveals the pinned image; content card overlaps its lower edge */}
-          {event.image && <div className="h-40 sm:h-48" aria-hidden="true" />}
+          {/* Spacer matching the image height so the content starts flush with the
+              image bottom and only overlaps once the user scrolls */}
+          {event.image && <div className="h-48 sm:h-56" aria-hidden="true" />}
 
           {/* Content card */}
           <div className="relative bg-[var(--pyre-black)] rounded-t-2xl px-6 pt-8 pb-6">

--- a/apps/landing-page/src/components/events/EventDetailModal.tsx
+++ b/apps/landing-page/src/components/events/EventDetailModal.tsx
@@ -1,7 +1,7 @@
 // Event detail modal — shows full event info with booking CTA
 // Rendered via createPortal to escape Astro layout constraints
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import type { EventItem } from '@/lib/types';
 
@@ -95,6 +95,39 @@ function ArrowIcon() {
   );
 }
 
+function ShareIcon() {
+  return (
+    <svg
+      className="w-4 h-4"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"
+      />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg
+      className="w-4 h-4"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+    </svg>
+  );
+}
+
 // -- Helpers ------------------------------------------------------------------
 
 function spotsColor(spots: number | undefined): string {
@@ -120,6 +153,7 @@ export default function EventDetailModal({ event, isOpen, onClose }: EventDetail
   const panelRef = useRef<HTMLDivElement>(null);
   const closeBtnRef = useRef<HTMLButtonElement>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
+  const [copied, setCopied] = useState(false);
 
   // Body scroll lock + keyboard handling + focus management
   useEffect(() => {
@@ -177,6 +211,44 @@ export default function EventDetailModal({ event, isOpen, onClose }: EventDetail
   const spots = spotsLabel(event.spotsRemaining, event.totalSpots);
   const isWaitlist = event.spotsRemaining === 0;
   const ctaLabel = isWaitlist ? 'Join Waitlist' : (event.cta?.label ?? 'Book Now');
+
+  // Build a deep-link to this event (with UTM tags) and share via the native
+  // share sheet when available, otherwise copy it to the clipboard.
+  async function handleShare() {
+    if (!event) return;
+
+    const url = new URL(`${window.location.origin}/events`);
+    url.searchParams.set('event', event.id);
+    url.searchParams.set('utm_source', 'share');
+    url.searchParams.set('utm_medium', 'referral');
+    url.searchParams.set('utm_campaign', 'event_share');
+    url.searchParams.set('utm_content', event.id);
+    const shareUrl = url.toString();
+
+    if (navigator.share) {
+      try {
+        await navigator.share({
+          title: event.title,
+          text: `Check out ${event.title} at Pyre`,
+          url: shareUrl,
+        });
+      } catch (err) {
+        // Ignore user-cancelled shares; surface anything else.
+        if ((err as Error)?.name !== 'AbortError') {
+          console.error('Share failed:', err);
+        }
+      }
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy link:', err);
+    }
+  }
 
   const modal = (
     <div
@@ -289,21 +361,33 @@ export default function EventDetailModal({ event, isOpen, onClose }: EventDetail
           </div>
         </div>
 
-        {/* Fixed footer — Book Now CTA stays anchored at the bottom */}
-        {!event.isPrivate && event.cta && (
-          <div className="relative z-20 border-t border-[var(--pyre-creme)]/10 bg-[var(--pyre-black)] px-6 py-4">
+        {/* Fixed footer — Share + Book Now stay anchored at the bottom */}
+        <div className="relative z-20 flex items-center gap-3 border-t border-[var(--pyre-creme)]/10 bg-[var(--pyre-black)] px-6 py-4">
+          {/* Share button */}
+          <button
+            type="button"
+            onClick={handleShare}
+            aria-label="Share this event"
+            className={`inline-flex items-center justify-center gap-2 rounded-full border border-[var(--pyre-creme)]/25 px-4 py-3 font-mono-bold text-sm uppercase tracking-wide text-[var(--pyre-creme)] transition-colors hover:bg-[var(--pyre-creme)]/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pyre-gold)]/50 ${!event.isPrivate && event.cta ? 'shrink-0' : 'w-full'}`}
+          >
+            {copied ? <CheckIcon /> : <ShareIcon />}
+            {copied ? 'Copied!' : 'Share'}
+          </button>
+
+          {/* Book Now CTA */}
+          {!event.isPrivate && event.cta && (
             <a
               href={event.cta.href}
               target="_blank"
               rel="noopener noreferrer"
               aria-label={event.cta.ariaLabel ?? `Book ${event.title}`}
-              className="flex w-full items-center justify-center gap-2 rounded-full bg-[var(--pyre-red)] px-6 py-3 font-mono-bold text-sm uppercase tracking-wide text-[var(--pyre-creme)] transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pyre-red)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--pyre-black)]"
+              className="flex flex-1 items-center justify-center gap-2 rounded-full bg-[var(--pyre-red)] px-6 py-3 font-mono-bold text-sm uppercase tracking-wide text-[var(--pyre-creme)] transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pyre-red)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--pyre-black)]"
             >
               {ctaLabel}
               <ArrowIcon />
             </a>
-          </div>
-        )}
+          )}
+        </div>
       </div>
     </div>
   );

--- a/apps/landing-page/src/components/events/EventDetailModal.tsx
+++ b/apps/landing-page/src/components/events/EventDetailModal.tsx
@@ -238,7 +238,7 @@ export default function EventDetailModal({ event, isOpen, onClose }: EventDetail
             {/* Gradient drop-shadow glow on the top edge as the card slides over the image */}
             <div
               aria-hidden="true"
-              className="pointer-events-none absolute inset-x-0 -top-4 h-8 rounded-[2rem] bg-gradient-to-r from-[var(--pyre-sage)] via-[var(--pyre-gold)] to-[var(--pyre-sage)] opacity-70 blur-xl"
+              className="pointer-events-none absolute inset-x-0 -top-2 h-5 rounded-[2rem] bg-gradient-to-r from-[var(--pyre-sage)] via-[var(--pyre-gold)] to-[var(--pyre-sage)] opacity-30 blur-2xl"
             />
 
             {/* Title */}

--- a/apps/landing-page/src/components/events/EventDetailModal.tsx
+++ b/apps/landing-page/src/components/events/EventDetailModal.tsx
@@ -235,6 +235,12 @@ export default function EventDetailModal({ event, isOpen, onClose }: EventDetail
 
           {/* Content card */}
           <div className="relative bg-[var(--pyre-black)] rounded-t-2xl px-6 pt-8 pb-6">
+            {/* Gradient drop-shadow glow on the top edge as the card slides over the image */}
+            <div
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-x-0 -top-4 h-8 rounded-[2rem] bg-gradient-to-r from-[var(--pyre-sage)] via-[var(--pyre-gold)] to-[var(--pyre-sage)] opacity-70 blur-xl"
+            />
+
             {/* Title */}
             <h2
               id="event-detail-title"

--- a/apps/landing-page/src/components/events/EventsGrid.tsx
+++ b/apps/landing-page/src/components/events/EventsGrid.tsx
@@ -199,7 +199,7 @@ function SlotRow({
         className="group flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-4 py-3 px-4 rounded-md border border-transparent cursor-pointer transition-colors hover:border-current/10 hover:bg-current/[0.03]"
       >
         {/* Title */}
-        <span className="font-mono-bold text-sm uppercase tracking-wide text-[var(--pyre-creme)] flex items-center justify-between sm:justify-start sm:w-56 shrink-0">
+        <span className="font-mono-bold text-sm uppercase tracking-wide text-[var(--pyre-creme)] flex items-center justify-between sm:justify-start sm:w-72 shrink-0">
           <span className="truncate">{event.title}</span>
           {/* Mobile-only Private label */}
           <span className="sm:hidden inline-flex items-center text-xs font-mono-bold uppercase tracking-wide border border-current/40 rounded-full px-3 py-1 text-[var(--pyre-creme)]/50 whitespace-nowrap ml-2">
@@ -242,7 +242,7 @@ function SlotRow({
       className="group flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-4 py-3 px-4 rounded-md border border-transparent cursor-pointer transition-colors hover:border-current/10 hover:bg-current/[0.03]"
     >
       {/* Title */}
-      <span className="font-mono-bold text-sm uppercase tracking-wide text-[var(--pyre-creme)] flex items-center justify-between sm:justify-start sm:w-56 shrink-0">
+      <span className="font-mono-bold text-sm uppercase tracking-wide text-[var(--pyre-creme)] flex items-center justify-between sm:justify-start sm:w-72 shrink-0">
         <span className="truncate">{event.title}</span>
         {/* Mobile-only CTA pill */}
         <a


### PR DESCRIPTION
## Events page & modal improvements

### Events list (`/events`)
- Widen the event title column so titles are cut off less aggressively.

### Event modal
- Close button now has a translucent dark circular background with a gold rim, so it stays visible over any header image.
- Restructured layout: the header image stays pinned at the top, the content/description card scrolls up over it, and the Book Now CTA is anchored as a fixed footer.
- The description card starts flush with the bottom of the image and only overlaps it once the user scrolls.
- Added a soft green→gold gradient drop-shadow glow on the description's top edge as it slides over the image.
- Added a Share button that generates a UTM-tagged deep link to the specific event, using the native share sheet when available and falling back to copy-to-clipboard. The footer now renders for all events (including private ones).