### PR TITLE
Define missing --pyre-burnt-orange brand token

### DIFF
--- a/apps/landing-page/src/styles/global.css
+++ b/apps/landing-page/src/styles/global.css
@@ -124,6 +124,7 @@
   --pyre-muted-gold: oklch(0.7472 0.0902 77.47); /* #cda56a | rgb(205, 166, 106) */
   --pyre-sage: oklch(0.65 0.06 130); /* #839770 | rgb(131, 151, 112) */
   --pyre-sky: oklch(0.62 0.1 230); /* #3991b7 | rgb(57, 145, 183) */
+  --pyre-burnt-orange: oklch(0.63 0.14 48); /* #cb6b34 | rgb(203, 107, 52) */
 
   /* Pyre Design System - 2-Color Rule */
 


### PR DESCRIPTION
## Problem

`--pyre-burnt-orange` is referenced in **5 places** but **never defined** in `global.css`, so those elements render with an invalid color (no badge background, inherited text color instead of the intended accent):

- `SignupForm.astro` — error message text
- `PromoPopup.astro` — error message text
- `EventsSection.astro` — event date badge
- `events/EventsCarousel.tsx` — event date badge
- `events/EventsGrid.tsx` — empty-state button (bg + hover + focus ring)

## Fix

Add the token to the brand palette as a true **burnt orange** — `oklch(0.63 0.14 48)` / **#cb6b34** — sitting between brand red (#d15232) and gold (#dbb155). One definition fixes all five usages; no per-component changes needed.