### PR TITLE
Implement short link management and UTM link relabeling

### DIFF
--- a/apps/landing-page/src/components/admin/UtmAssist.tsx
+++ b/apps/landing-page/src/components/admin/UtmAssist.tsx
@@ -39,8 +39,18 @@ const EMPTY_UTM: UtmFields = {
 // Curated, built-in presets seeded for the team. Users can add their own on top
 // of these (persisted to localStorage); curated ones can't be removed.
 const CURATED_PRESETS: Record<keyof UtmFields, string[]> = {
-  source: ['instagram', 'facebook', 'email', 'newsletter', 'qr', 'print', 'google', 'linkedin'],
-  medium: ['social', 'paid_social', 'email', 'cpc', 'referral', 'qr', 'print'],
+  source: [
+    'sms',
+    'instagram',
+    'facebook',
+    'email',
+    'newsletter',
+    'qr',
+    'print',
+    'google',
+    'linkedin',
+  ],
+  medium: ['sms', 'social', 'paid_social', 'email', 'cpc', 'referral', 'qr', 'print'],
   campaign: [],
   term: [],
   content: ['header', 'footer', 'cta-button', 'bio-link', 'story-link'],
@@ -61,6 +71,8 @@ const FIELD_INFO: Record<string, string> = {
   term: 'Optional. The paid-search keyword you are bidding on.',
   content: 'Optional. Tells apart two links to the same place. e.g. header-button vs footer-link.',
   link: 'The finished tracked URL. Copy it and share.',
+  shorten:
+    'Turns the tracked link into a short pyresauna.com/s/… link. The texted message stays clean while the UTM tags still load on the destination, so attribution keeps working.',
 };
 
 // User-created presets are persisted per browser so campaigns/terms can be
@@ -227,6 +239,31 @@ interface SavedLink {
 interface CampaignWithLinks {
   campaign: SavedCampaign;
   links: SavedLink[];
+}
+
+// One row of the "Recent short links" list (mirrors the server ShortLink shape,
+// minus fields the UI doesn't render).
+interface ShortLinkRow {
+  code: string;
+  url: string;
+  label: string;
+  createdAt: number;
+  clicks: number;
+}
+
+function shortErrorMessage(code: unknown): string {
+  switch (code) {
+    case 'alias_taken':
+      return 'That custom alias is already taken.';
+    case 'invalid_alias':
+      return 'Alias can only contain letters, numbers, - and _.';
+    case 'storage_unavailable':
+      return 'Link storage is unavailable right now.';
+    case 'URL must point to this site':
+      return 'Can only shorten links to this site.';
+    default:
+      return 'Failed to create short link.';
+  }
 }
 
 // ── QR styling ──────────────────────────────────────────────────────────────
@@ -594,6 +631,26 @@ export function UtmAssist({ origin, blogPosts }: UtmAssistProps) {
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  // Inline relabel of a saved campaign link, and per-link QR visibility (QRs are
+  // hidden by default and revealed on demand to keep long campaigns light).
+  const [editingLinkId, setEditingLinkId] = useState<string | null>(null);
+  const [editLinkLabel, setEditLinkLabel] = useState('');
+  const [shownQr, setShownQr] = useState<Record<string, boolean>>({});
+
+  // Short-link creation + recent-links list. The result/error carry the exact URL
+  // they belong to (`forUrl`) so they auto-hide once the built URL changes.
+  const [shortLabel, setShortLabel] = useState('');
+  const [shortAlias, setShortAlias] = useState('');
+  const [shortResult, setShortResult] = useState<{ shortUrl: string; forUrl: string } | null>(null);
+  const [shortLoading, setShortLoading] = useState(false);
+  const [shortError, setShortError] = useState<{ message: string; forUrl: string } | null>(null);
+  const [shortCopied, setShortCopied] = useState(false);
+  const [recent, setRecent] = useState<ShortLinkRow[] | null>(null);
+  const [recentLoading, setRecentLoading] = useState(false);
+  const [recentOpen, setRecentOpen] = useState(false);
+  const [copiedCode, setCopiedCode] = useState<string | null>(null);
+  const [editingCode, setEditingCode] = useState<string | null>(null);
+  const [editLabel, setEditLabel] = useState('');
 
   useEffect(() => {
     if (authLoading) return;
@@ -820,6 +877,174 @@ export function UtmAssist({ origin, blogPosts }: UtmAssistProps) {
     }
   }, []);
 
+  const startEditLink = useCallback((link: SavedLink) => {
+    setEditingLinkId(link.id);
+    setEditLinkLabel(link.label);
+  }, []);
+
+  const cancelEditLink = useCallback(() => {
+    setEditingLinkId(null);
+    setEditLinkLabel('');
+  }, []);
+
+  // Relabel a saved campaign link, then patch the new label into local state.
+  const saveEditLink = useCallback(
+    async (id: string) => {
+      const label = editLinkLabel.trim();
+      try {
+        const res = await fetch('/api/admin/utm-links', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ id, label }),
+        });
+        if (!res.ok) throw new Error();
+        setCampaigns((prev) =>
+          prev
+            ? prev.map((c) => ({
+                ...c,
+                links: c.links.map((l) => (l.id === id ? { ...l, label } : l)),
+              }))
+            : prev
+        );
+      } catch {
+        // Leave the link unchanged on failure.
+      } finally {
+        setEditingLinkId(null);
+        setEditLinkLabel('');
+      }
+    },
+    [editLinkLabel]
+  );
+
+  const toggleQr = useCallback((id: string) => {
+    setShownQr((prev) => ({ ...prev, [id]: !prev[id] }));
+  }, []);
+
+  const loadRecent = useCallback(async () => {
+    setRecentLoading(true);
+    try {
+      const res = await fetch('/api/admin/shortlinks?limit=25');
+      if (!res.ok) throw new Error();
+      const data = (await res.json()) as { links?: ShortLinkRow[] };
+      setRecent(Array.isArray(data.links) ? data.links : []);
+    } catch {
+      setRecent([]);
+    } finally {
+      setRecentLoading(false);
+    }
+  }, []);
+
+  const toggleRecent = useCallback(() => {
+    setRecentOpen((open) => {
+      const next = !open;
+      if (next && recent === null) void loadRecent();
+      return next;
+    });
+  }, [recent, loadRecent]);
+
+  const createShort = useCallback(async () => {
+    if (!generatedUrl) return;
+    const forUrl = generatedUrl;
+    setShortLoading(true);
+    setShortError(null);
+    setShortResult(null);
+    try {
+      const res = await fetch('/api/admin/shortlinks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          url: forUrl,
+          label: shortLabel.trim() || undefined,
+          alias: shortAlias.trim() || undefined,
+        }),
+      });
+      const data = (await res.json()) as { shortUrl?: string; error?: string };
+      if (!res.ok || !data.shortUrl) throw new Error(shortErrorMessage(data.error));
+      setShortResult({ shortUrl: data.shortUrl, forUrl });
+      setShortAlias('');
+      if (recent !== null) void loadRecent();
+    } catch (err) {
+      setShortError({
+        message: err instanceof Error ? err.message : shortErrorMessage(undefined),
+        forUrl,
+      });
+    } finally {
+      setShortLoading(false);
+    }
+  }, [generatedUrl, shortLabel, shortAlias, recent, loadRecent]);
+
+  const copyShort = useCallback(async () => {
+    if (!shortResult) return;
+    try {
+      await navigator.clipboard.writeText(shortResult.shortUrl);
+      setShortCopied(true);
+      setTimeout(() => setShortCopied(false), 1500);
+    } catch {
+      // Clipboard not available
+    }
+  }, [shortResult]);
+
+  const copyRow = useCallback(async (code: string, value: string) => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopiedCode(code);
+      setTimeout(() => setCopiedCode((c) => (c === code ? null : c)), 1500);
+    } catch {
+      // Clipboard not available
+    }
+  }, []);
+
+  const startEditRow = useCallback((row: ShortLinkRow) => {
+    setEditingCode(row.code);
+    setEditLabel(row.label);
+  }, []);
+
+  const cancelEditRow = useCallback(() => {
+    setEditingCode(null);
+    setEditLabel('');
+  }, []);
+
+  // Rename/retag: persist the new label, then patch it into the local list.
+  const saveEditRow = useCallback(
+    async (code: string) => {
+      const label = editLabel.trim();
+      try {
+        const res = await fetch('/api/admin/shortlinks', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ code, label }),
+        });
+        if (!res.ok) throw new Error();
+        setRecent((prev) => prev?.map((r) => (r.code === code ? { ...r, label } : r)) ?? prev);
+      } catch {
+        // Leave the row unchanged on failure.
+      } finally {
+        setEditingCode(null);
+        setEditLabel('');
+      }
+    },
+    [editLabel]
+  );
+
+  const deleteRow = useCallback(
+    async (code: string) => {
+      if (!window.confirm(`Delete short link /s/${code}? Any texts using it will stop working.`)) {
+        return;
+      }
+      // Remove from view immediately; only re-sync if the delete fails.
+      setRecent((prev) => prev?.filter((r) => r.code !== code) ?? prev);
+      try {
+        const res = await fetch(`/api/admin/shortlinks?code=${encodeURIComponent(code)}`, {
+          method: 'DELETE',
+        });
+        if (!res.ok) throw new Error();
+      } catch {
+        void loadRecent();
+      }
+    },
+    [loadRecent]
+  );
+
   if (authLoading || gate === 'checking') {
     return (
       <div className="flex items-center justify-center min-h-[400px]">
@@ -950,6 +1175,7 @@ export function UtmAssist({ origin, blogPosts }: UtmAssistProps) {
                 <option key={event.id} value={event.id}>
                   {event.title}
                   {event.date ? ` — ${event.date}` : ''}
+                  {event.time ? ` at ${event.time}` : ''}
                 </option>
               ))}
             </select>
@@ -1071,6 +1297,160 @@ export function UtmAssist({ origin, blogPosts }: UtmAssistProps) {
         )}
       </div>
 
+      {/* Short link (for SMS) */}
+      <div className="mt-8 pt-6 border-t border-white/10">
+        <FieldLabel info={FIELD_INFO.shorten}>Short link (for SMS)</FieldLabel>
+        <p className="text-xs text-white/40 -mt-1 mb-3">
+          Hides the UTM params in the texted message. Tracking still works when the link opens.
+        </p>
+        <div className="grid sm:grid-cols-2 gap-2 mb-2">
+          <input
+            value={shortLabel}
+            onChange={(e) => setShortLabel(e.target.value)}
+            placeholder="Label (optional, e.g. July SMS blast)"
+            autoComplete="off"
+            className={inputClass}
+          />
+          <input
+            value={shortAlias}
+            onChange={(e) => setShortAlias(e.target.value)}
+            placeholder="Custom alias (optional)"
+            autoComplete="off"
+            className={inputClass}
+          />
+        </div>
+        <button
+          type="button"
+          onClick={createShort}
+          disabled={!generatedUrl || shortLoading}
+          className="px-4 py-2 rounded font-mono-bold text-sm uppercase tracking-wide border border-white/20 text-white/70 hover:text-white hover:border-white/40 transition-colors disabled:opacity-40"
+        >
+          {shortLoading ? 'Creating…' : 'Create short link'}
+        </button>
+        {shortError?.forUrl === generatedUrl && (
+          <p className="mt-2 text-sm text-[var(--pyre-red)]">{shortError.message}</p>
+        )}
+        {shortResult?.forUrl === generatedUrl && (
+          <div className="mt-3 flex flex-col sm:flex-row gap-2">
+            <output className="flex-1 px-3 py-2 rounded bg-white/5 border border-white/10 text-sm font-mono text-[var(--pyre-creme)] break-all min-h-[2.5rem]">
+              {shortResult.shortUrl}
+            </output>
+            <button
+              type="button"
+              onClick={copyShort}
+              className="px-4 py-2 rounded font-mono-bold text-sm uppercase tracking-wide bg-[var(--pyre-red)] text-[var(--pyre-creme)] hover:opacity-90 transition-opacity whitespace-nowrap"
+            >
+              {shortCopied ? 'Copied' : 'Copy'}
+            </button>
+          </div>
+        )}
+
+        {/* Recent short links */}
+        <div className="mt-4">
+          <button
+            type="button"
+            onClick={toggleRecent}
+            aria-expanded={recentOpen}
+            className="flex items-center gap-2 text-xs font-mono-bold uppercase tracking-wide text-white/40 hover:text-white transition-colors"
+          >
+            <span aria-hidden>{recentOpen ? '▾' : '▸'}</span> Recent short links
+          </button>
+          {recentOpen && (
+            <div className="mt-3">
+              {recentLoading && <p className="text-sm text-white/40">Loading…</p>}
+              {!recentLoading && recent && recent.length === 0 && (
+                <p className="text-sm text-white/40">No short links yet.</p>
+              )}
+              {!recentLoading && recent && recent.length > 0 && (
+                <ul className="flex flex-col gap-2">
+                  {recent.map((row) => {
+                    const rowUrl = `${origin}/s/${row.code}`;
+                    const isEditing = editingCode === row.code;
+                    const btnClass =
+                      'shrink-0 px-3 py-1.5 rounded border border-white/20 text-xs font-mono-bold uppercase tracking-wide text-white/60 hover:text-white hover:border-white/40 transition-colors';
+                    return (
+                      <li
+                        key={row.code}
+                        className="flex items-center gap-3 rounded border border-white/10 bg-white/5 px-3 py-2"
+                      >
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center gap-2">
+                            <span className="font-mono text-sm text-[var(--pyre-creme)] truncate">
+                              /s/{row.code}
+                            </span>
+                            {isEditing ? (
+                              <input
+                                value={editLabel}
+                                onChange={(e) => setEditLabel(e.target.value)}
+                                onKeyDown={(e) => {
+                                  if (e.key === 'Enter') void saveEditRow(row.code);
+                                  if (e.key === 'Escape') cancelEditRow();
+                                }}
+                                placeholder="Label"
+                                // biome-ignore lint/a11y/noAutofocus: focus the field the admin just opened
+                                autoFocus
+                                className="min-w-0 flex-1 px-2 py-0.5 rounded bg-white/5 border border-white/20 text-xs text-[var(--pyre-creme)] focus:outline-none focus:border-white/40"
+                              />
+                            ) : (
+                              row.label && (
+                                <span className="text-xs text-white/40 truncate">{row.label}</span>
+                              )
+                            )}
+                          </div>
+                          <div className="text-xs text-white/30 truncate">{row.url}</div>
+                        </div>
+                        {isEditing ? (
+                          <>
+                            <button
+                              type="button"
+                              onClick={() => void saveEditRow(row.code)}
+                              className={btnClass}
+                            >
+                              Save
+                            </button>
+                            <button type="button" onClick={cancelEditRow} className={btnClass}>
+                              Cancel
+                            </button>
+                          </>
+                        ) : (
+                          <>
+                            <span className="shrink-0 text-xs text-white/40">
+                              {row.clicks} {row.clicks === 1 ? 'click' : 'clicks'}
+                            </span>
+                            <button
+                              type="button"
+                              onClick={() => copyRow(row.code, rowUrl)}
+                              className={btnClass}
+                            >
+                              {copiedCode === row.code ? 'Copied' : 'Copy'}
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => startEditRow(row)}
+                              className={btnClass}
+                            >
+                              Edit
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => void deleteRow(row.code)}
+                              aria-label={`Delete short link ${row.code}`}
+                              className="shrink-0 px-3 py-1.5 rounded border border-white/20 text-xs font-mono-bold uppercase tracking-wide text-white/40 hover:text-[var(--pyre-red)] hover:border-[var(--pyre-red)]/50 transition-colors"
+                            >
+                              Delete
+                            </button>
+                          </>
+                        )}
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
       {/* Save to a shared campaign — grouped by the utm_campaign value */}
       <div className="mt-8 pt-6 border-t border-white/10">
         <FieldLabel info="Saves this link into the shared campaign named by its utm_campaign value, so the whole team can reuse it.">
@@ -1155,44 +1535,105 @@ export function UtmAssist({ origin, blogPosts }: UtmAssistProps) {
                     {links.length === 0 && (
                       <p className="px-3 py-3 text-sm text-white/40">No links saved yet.</p>
                     )}
-                    {links.map((link) => (
-                      <div key={link.id} className="px-3 py-3 flex flex-col sm:flex-row gap-3">
-                        <div className="flex-1 min-w-0">
-                          {link.label && (
-                            <p className="text-sm text-[var(--pyre-creme)] mb-0.5">{link.label}</p>
-                          )}
-                          <p className="text-xs font-mono text-white/50 break-all">{link.url}</p>
-                          <div className="mt-2 flex gap-2">
-                            <button
-                              type="button"
-                              onClick={() => copyLink(link.url)}
-                              className="px-2 py-1 rounded border border-white/20 text-xs text-white/60 hover:text-white hover:border-white/40 transition-colors"
-                            >
-                              Copy
-                            </button>
-                            <button
-                              type="button"
-                              onClick={() => deleteLink(link.id)}
-                              className="px-2 py-1 rounded border border-white/20 text-xs text-white/40 hover:text-[var(--pyre-red)] hover:border-[var(--pyre-red)]/50 transition-colors"
-                            >
-                              Delete
-                            </button>
+                    {links.map((link) => {
+                      const isEditingLink = editingLinkId === link.id;
+                      const qrShown = shownQr[link.id] ?? false;
+                      const linkBtn =
+                        'px-2 py-1 rounded border border-white/20 text-xs text-white/60 hover:text-white hover:border-white/40 transition-colors';
+                      return (
+                        <div key={link.id} className="px-3 py-3 flex flex-col sm:flex-row gap-3">
+                          <div className="flex-1 min-w-0">
+                            {isEditingLink ? (
+                              <input
+                                value={editLinkLabel}
+                                onChange={(e) => setEditLinkLabel(e.target.value)}
+                                onKeyDown={(e) => {
+                                  if (e.key === 'Enter') void saveEditLink(link.id);
+                                  if (e.key === 'Escape') cancelEditLink();
+                                }}
+                                placeholder="Label"
+                                // biome-ignore lint/a11y/noAutofocus: focus the field the admin just opened
+                                autoFocus
+                                className="w-full mb-1 px-2 py-1 rounded bg-white/5 border border-white/20 text-sm text-[var(--pyre-creme)] focus:outline-none focus:border-white/40"
+                              />
+                            ) : (
+                              link.label && (
+                                <p className="text-sm text-[var(--pyre-creme)] mb-0.5">
+                                  {link.label}
+                                </p>
+                              )
+                            )}
+                            <p className="text-xs font-mono text-white/50 break-all">{link.url}</p>
+                            <div className="mt-2 flex flex-wrap gap-2">
+                              {isEditingLink ? (
+                                <>
+                                  <button
+                                    type="button"
+                                    onClick={() => void saveEditLink(link.id)}
+                                    className={linkBtn}
+                                  >
+                                    Save
+                                  </button>
+                                  <button
+                                    type="button"
+                                    onClick={cancelEditLink}
+                                    className={linkBtn}
+                                  >
+                                    Cancel
+                                  </button>
+                                </>
+                              ) : (
+                                <>
+                                  <button
+                                    type="button"
+                                    onClick={() => copyLink(link.url)}
+                                    className={linkBtn}
+                                  >
+                                    Copy
+                                  </button>
+                                  <button
+                                    type="button"
+                                    onClick={() => startEditLink(link)}
+                                    className={linkBtn}
+                                  >
+                                    Edit
+                                  </button>
+                                  <button
+                                    type="button"
+                                    onClick={() => toggleQr(link.id)}
+                                    aria-expanded={qrShown}
+                                    className={linkBtn}
+                                  >
+                                    {qrShown ? 'Hide QR' : 'Show QR'}
+                                  </button>
+                                  <button
+                                    type="button"
+                                    onClick={() => deleteLink(link.id)}
+                                    className="px-2 py-1 rounded border border-white/20 text-xs text-white/40 hover:text-[var(--pyre-red)] hover:border-[var(--pyre-red)]/50 transition-colors"
+                                  >
+                                    Delete
+                                  </button>
+                                </>
+                              )}
+                            </div>
                           </div>
+                          {qrShown && (
+                            <div className="shrink-0">
+                              <QrCode
+                                url={link.url}
+                                filename={qrFilename([
+                                  campaign.name,
+                                  link.label,
+                                  link.source,
+                                  link.medium,
+                                ])}
+                                style={qrStyle}
+                              />
+                            </div>
+                          )}
                         </div>
-                        <div className="shrink-0">
-                          <QrCode
-                            url={link.url}
-                            filename={qrFilename([
-                              campaign.name,
-                              link.label,
-                              link.source,
-                              link.medium,
-                            ])}
-                            style={qrStyle}
-                          />
-                        </div>
-                      </div>
-                    ))}
+                      );
+                    })}
                   </div>
                 )}
               </div>

--- a/apps/landing-page/src/pages/api/admin/shortlinks.ts
+++ b/apps/landing-page/src/pages/api/admin/shortlinks.ts
@@ -1,0 +1,119 @@
+// Admin-only short-link management. POST creates a short link for a UTM-tagged
+// URL built in the UTM Assist tool; GET lists recent links for reuse.
+
+import {
+  createShortLink,
+  deleteShortLink,
+  listShortLinks,
+  ShortLinkError,
+  updateShortLinkLabel,
+} from '@pyre/webhook-core';
+import type { APIRoute } from 'astro';
+import { isAdminEmail } from '@/lib/admin';
+import { validateSession } from '@/lib/auth-session';
+
+export const prerender = false;
+
+const JSON_HEADERS = { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' };
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), { status, headers: JSON_HEADERS });
+}
+
+async function requireAdmin(cookies: Parameters<APIRoute>[0]['cookies']) {
+  const { session } = await validateSession(cookies);
+  if (!session.isAuthenticated || !session.user) {
+    return { error: json({ error: 'Not authenticated' }, 401) };
+  }
+  if (!session.user.email || !isAdminEmail(session.user.email)) {
+    return { error: json({ error: 'Forbidden' }, 403) };
+  }
+  return { email: session.user.email };
+}
+
+export const GET: APIRoute = async ({ cookies, url }) => {
+  const auth = await requireAdmin(cookies);
+  if (auth.error) return auth.error;
+
+  const limit = Math.min(Number(url.searchParams.get('limit') ?? '50'), 200);
+  const offset = Math.max(Number(url.searchParams.get('offset') ?? '0'), 0);
+
+  const { links, total } = await listShortLinks(limit, offset);
+  return json({ links, total, limit, offset }, 200);
+};
+
+export const POST: APIRoute = async ({ cookies, request, url }) => {
+  const auth = await requireAdmin(cookies);
+  if (auth.error) return auth.error;
+
+  let body: { url?: string; label?: string; alias?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: 'Invalid JSON' }, 400);
+  }
+
+  const targetUrl = (body.url ?? '').trim();
+  if (!targetUrl) return json({ error: 'Missing url' }, 400);
+
+  // Only shorten links back to our own site — never let this become an open
+  // redirector to arbitrary external hosts.
+  let parsed: URL;
+  try {
+    parsed = new URL(targetUrl);
+  } catch {
+    return json({ error: 'Invalid url' }, 400);
+  }
+  if (parsed.origin !== url.origin) {
+    return json({ error: 'URL must point to this site' }, 400);
+  }
+
+  try {
+    const link = await createShortLink({
+      url: targetUrl,
+      label: body.label,
+      alias: body.alias?.trim() || undefined,
+      createdBy: auth.email,
+    });
+    return json({ ...link, shortUrl: `${url.origin}/s/${link.code}` }, 201);
+  } catch (err) {
+    if (err instanceof ShortLinkError) {
+      const status = err.code === 'alias_taken' ? 409 : 400;
+      return json({ error: err.code }, status);
+    }
+    console.error('[shortlinks] create failed:', err);
+    return json({ error: 'server_error' }, 500);
+  }
+};
+
+// Rename/retag: change only the label of an existing short link.
+export const PATCH: APIRoute = async ({ cookies, request }) => {
+  const auth = await requireAdmin(cookies);
+  if (auth.error) return auth.error;
+
+  let body: { code?: string; label?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: 'Invalid JSON' }, 400);
+  }
+
+  const code = (body.code ?? '').trim();
+  if (!code) return json({ error: 'Missing code' }, 400);
+
+  const link = await updateShortLinkLabel(code, body.label ?? '');
+  if (!link) return json({ error: 'Not found' }, 404);
+  return json(link, 200);
+};
+
+// Remove a short link that's no longer needed.
+export const DELETE: APIRoute = async ({ cookies, url }) => {
+  const auth = await requireAdmin(cookies);
+  if (auth.error) return auth.error;
+
+  const code = (url.searchParams.get('code') ?? '').trim();
+  if (!code) return json({ error: 'Missing code' }, 400);
+
+  await deleteShortLink(code);
+  return json({ ok: true }, 200);
+};

--- a/apps/landing-page/src/pages/api/admin/utm-links.ts
+++ b/apps/landing-page/src/pages/api/admin/utm-links.ts
@@ -1,4 +1,4 @@
-import { createCampaign, deleteLink, saveLink } from '@pyre/webhook-core';
+import { createCampaign, deleteLink, saveLink, updateLinkLabel } from '@pyre/webhook-core';
 import type { APIRoute } from 'astro';
 import { isAdminEmail } from '@/lib/admin';
 import { validateSession } from '@/lib/auth-session';
@@ -78,6 +78,30 @@ export const DELETE: APIRoute = async ({ cookies, url }) => {
   try {
     await deleteLink(id);
     return json({ ok: true });
+  } catch (err) {
+    return json({ error: err instanceof Error ? err.message : 'Unknown error' }, 500);
+  }
+};
+
+// Relabel a saved link (only the friendly label changes).
+export const PATCH: APIRoute = async ({ cookies, request }) => {
+  const auth = await requireAdmin(cookies);
+  if ('error' in auth) return auth.error;
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return json({ error: 'Invalid JSON body' }, 400);
+  }
+
+  const id = str(body.id);
+  if (!id) return json({ error: 'id is required' }, 400);
+
+  try {
+    const link = await updateLinkLabel(id, str(body.label));
+    if (!link) return json({ error: 'Link not found' }, 404);
+    return json({ link });
   } catch (err) {
     return json({ error: err instanceof Error ? err.message : 'Unknown error' }, 500);
   }

--- a/apps/landing-page/src/pages/s/[code].ts
+++ b/apps/landing-page/src/pages/s/[code].ts
@@ -1,0 +1,37 @@
+// Public short-link redirect: /s/<code> → the stored (UTM-tagged) URL.
+// Keeps the texted link clean while the destination still carries utm_* params,
+// so pyreAttribution() (posthog.astro) can read them on landing.
+
+import { getShortLink, incrementClickCount } from '@pyre/webhook-core';
+import type { APIRoute } from 'astro';
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ params, redirect }) => {
+  const code = params.code;
+  if (!code) return redirect('/', 302);
+
+  const link = await getShortLink(code);
+  if (!link?.url) return redirect('/', 302);
+
+  // Defense-in-depth: links are created same-origin, but never redirect to a
+  // non-http(s) target.
+  let target: URL;
+  try {
+    target = new URL(link.url);
+  } catch {
+    return redirect('/', 302);
+  }
+  if (target.protocol !== 'http:' && target.protocol !== 'https:') {
+    return redirect('/', 302);
+  }
+
+  // Count the click; a Redis hiccup must not break the redirect.
+  try {
+    await incrementClickCount(code);
+  } catch {
+    // best-effort
+  }
+
+  return redirect(target.toString(), 302);
+};

--- a/packages/webhook-core/src/index.ts
+++ b/packages/webhook-core/src/index.ts
@@ -21,9 +21,23 @@ export {
   listCampaignsWithLinks,
   saveLink,
   slugifyCampaign,
+  updateLinkLabel,
   type UtmCampaign,
   type UtmLink,
 } from './utm-campaign-store';
+export {
+  codeExists,
+  createShortLink,
+  type CreateShortLinkInput,
+  deleteShortLink,
+  getShortLink,
+  incrementClickCount,
+  isValidAlias,
+  listShortLinks,
+  type ShortLink,
+  ShortLinkError,
+  updateShortLinkLabel,
+} from './shortlinks';
 export { type TraceStep, WebhookTracer } from './tracer';
 export { createWebhookLogger, type WebhookLogger } from './logger';
 export {

--- a/packages/webhook-core/src/shortlinks.ts
+++ b/packages/webhook-core/src/shortlinks.ts
@@ -1,0 +1,164 @@
+import { getRedis } from './redis';
+
+// Short-link store. Mirrors the execution-store key contract (a hash per record
+// plus a sorted-set index), sharing the SAME Upstash instance. The landing-page
+// admin dashboard writes links here and the public `/s/[code]` redirect route
+// reads them, so this module is the single source of truth for the schema.
+const RECORD_PREFIX = 'shortlink:';
+const INDEX_KEY = 'shortlinks';
+
+// Unambiguous base62 alphabet for auto-generated codes.
+const CODE_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+const CODE_LENGTH = 6;
+const MAX_GENERATION_ATTEMPTS = 5;
+
+// Custom aliases: letters, digits, dash, underscore.
+const ALIAS_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/;
+
+export interface ShortLink {
+  code: string;
+  url: string;
+  label: string;
+  createdAt: number;
+  createdBy: string;
+  clicks: number;
+}
+
+export interface CreateShortLinkInput {
+  url: string;
+  createdBy: string;
+  label?: string;
+  alias?: string;
+}
+
+export class ShortLinkError extends Error {
+  constructor(public code: string) {
+    super(code);
+    this.name = 'ShortLinkError';
+  }
+}
+
+export function isValidAlias(alias: string): boolean {
+  return ALIAS_PATTERN.test(alias);
+}
+
+function generateCode(): string {
+  const bytes = new Uint8Array(CODE_LENGTH);
+  crypto.getRandomValues(bytes);
+  let out = '';
+  for (let i = 0; i < CODE_LENGTH; i++) {
+    out += CODE_ALPHABET[bytes[i] % CODE_ALPHABET.length];
+  }
+  return out;
+}
+
+export async function codeExists(code: string): Promise<boolean> {
+  const redis = getRedis();
+  if (!redis) return false;
+  return (await redis.exists(`${RECORD_PREFIX}${code}`)) === 1;
+}
+
+export async function getShortLink(code: string): Promise<ShortLink | null> {
+  const redis = getRedis();
+  if (!redis) return null;
+
+  const record = await redis.hgetall(`${RECORD_PREFIX}${code}`);
+  if (!record || Object.keys(record).length === 0) return null;
+
+  return record as unknown as ShortLink;
+}
+
+export async function createShortLink(input: CreateShortLinkInput): Promise<ShortLink> {
+  const redis = getRedis();
+  if (!redis) throw new ShortLinkError('storage_unavailable');
+
+  let code: string;
+  if (input.alias) {
+    if (!isValidAlias(input.alias)) throw new ShortLinkError('invalid_alias');
+    if (await codeExists(input.alias)) throw new ShortLinkError('alias_taken');
+    code = input.alias;
+  } else {
+    code = generateCode();
+    let attempts = 0;
+    while (await codeExists(code)) {
+      if (++attempts >= MAX_GENERATION_ATTEMPTS) {
+        throw new ShortLinkError('code_generation_failed');
+      }
+      code = generateCode();
+    }
+  }
+
+  const record: ShortLink = {
+    code,
+    url: input.url,
+    label: input.label?.trim() || '',
+    createdAt: Date.now(),
+    createdBy: input.createdBy,
+    clicks: 0,
+  };
+
+  const pipeline = redis.pipeline();
+  pipeline.hset(`${RECORD_PREFIX}${code}`, record);
+  pipeline.zadd(INDEX_KEY, { score: record.createdAt, member: code });
+  await pipeline.exec();
+
+  return record;
+}
+
+export async function listShortLinks(
+  limit = 50,
+  offset = 0
+): Promise<{ links: ShortLink[]; total: number }> {
+  const redis = getRedis();
+  if (!redis) return { links: [], total: 0 };
+
+  const total = await redis.zcard(INDEX_KEY);
+  if (total === 0) return { links: [], total: 0 };
+
+  const codes = await redis.zrange(INDEX_KEY, offset, offset + limit - 1, { rev: true });
+  if (codes.length === 0) return { links: [], total };
+
+  const pipeline = redis.pipeline();
+  for (const code of codes) {
+    pipeline.hgetall(`${RECORD_PREFIX}${code}`);
+  }
+
+  const results = await pipeline.exec();
+  const links = results.filter(Boolean) as ShortLink[];
+
+  return { links, total };
+}
+
+// Fire-and-forget from the redirect route; failures are non-fatal.
+export async function incrementClickCount(code: string): Promise<void> {
+  const redis = getRedis();
+  if (!redis) return;
+  await redis.hincrby(`${RECORD_PREFIX}${code}`, 'clicks', 1);
+}
+
+// Rename/retag: update only the human-readable label. The code (and therefore any
+// already-shared /s/<code> link) is left untouched. Returns the updated record,
+// or null if storage is unavailable or the code doesn't exist.
+export async function updateShortLinkLabel(
+  code: string,
+  label: string
+): Promise<ShortLink | null> {
+  const redis = getRedis();
+  if (!redis) return null;
+  if (!(await codeExists(code))) return null;
+
+  await redis.hset(`${RECORD_PREFIX}${code}`, { label: label.trim() });
+  return getShortLink(code);
+}
+
+// Remove a short link entirely. After this the /s/<code> route 404s (redirects
+// home). Drops both the record hash and the index entry.
+export async function deleteShortLink(code: string): Promise<void> {
+  const redis = getRedis();
+  if (!redis) return;
+
+  const pipeline = redis.pipeline();
+  pipeline.del(`${RECORD_PREFIX}${code}`);
+  pipeline.zrem(INDEX_KEY, code);
+  await pipeline.exec();
+}

--- a/packages/webhook-core/src/utm-campaign-store.ts
+++ b/packages/webhook-core/src/utm-campaign-store.ts
@@ -171,6 +171,20 @@ export async function saveLink(
   return link;
 }
 
+/** Relabel a saved link. Only the friendly label changes; the URL/UTM params and
+ * campaign membership are untouched. Returns the updated link, or null if it's
+ * gone or storage is unavailable. */
+export async function updateLinkLabel(id: string, label: string): Promise<UtmLink | null> {
+  const redis = getRedis();
+  if (!redis) return null;
+
+  const exists = await redis.exists(`${LINK_PREFIX}${id}`);
+  if (!exists) return null;
+
+  await redis.hset(`${LINK_PREFIX}${id}`, { label: label.trim() });
+  return (await redis.hgetall(`${LINK_PREFIX}${id}`)) as UtmLink | null;
+}
+
 /** Delete a single saved link, removing it from its campaign's link set. */
 export async function deleteLink(id: string): Promise<void> {
   const redis = getRedis();


### PR DESCRIPTION
- Added API endpoints for creating, retrieving, updating, and deleting short links, enhancing the UTM Assist tool's functionality.
- Introduced a new public redirect route for short links, ensuring clean URL sharing while preserving UTM parameters.
- Updated the UtmAssist component to support short link creation and management, improving user experience for admins.
- Enhanced existing UTM link management with the ability to relabel saved links, streamlining campaign adjustments.