### PR TITLE
Add pyre-agents Eve app for AI schedule drafting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ ds-bundle/
 .design-sync/.cache/
 .design-sync/learnings/
 .design-sync/node_modules
+
+# Eve (apps/agents) build artifacts
+apps/agents/.eve/
+apps/agents/.output/

--- a/apps/agents/.env.example
+++ b/apps/agents/.env.example
@@ -1,0 +1,22 @@
+# pyre-agents (Eve) environment. Key segmentation is per deployment boundary:
+# this app gets its own revocable Supabase secret key and two per-direction
+# secrets — see apps/integrations/docs/staff-scheduling-scope.md.
+
+# Local dev only — on Vercel, model calls use AI Gateway via project OIDC.
+AI_GATEWAY_API_KEY=
+
+# Direct table reads (mint a DEDICATED sb_secret_* key for agents in the
+# Supabase dashboard — do not reuse the integrations key).
+SUPABASE_URL=
+SUPABASE_AGENTS_SECRET_KEY=
+
+# Proposal writes go through the integrations app (validation lives there).
+INTEGRATIONS_BASE_URL=http://localhost:4330
+AGENT_API_SECRET=
+
+# Inbound auth for POST /eve/v1/session (the admin "Draft schedule" button
+# and any external trigger).
+EVE_CHANNEL_SECRET=
+
+# Evals / safety: force save_proposal to dryRun so nothing is written.
+# AGENT_FORCE_DRY_RUN=1

--- a/apps/agents/README.md
+++ b/apps/agents/README.md
@@ -1,0 +1,70 @@
+# pyre-agents
+
+Vercel [Eve](https://eve.dev) app hosting Pyre's AI agents — first up: the
+**staff-scheduling drafter**, which reviews upcoming coverage shifts (synced
+from Momence by the integrations app), everyone's time off, hours, and history
+patterns, then drafts a week of assignments the admin reviews on
+`/admin/schedule` (approve week, ✓/✗ per item, or discard).
+
+## How it fits together
+
+```
+Momence ──(sync-shifts cron + admin buttons, apps/integrations)──▶ shifts table
+                                                                      │
+agent/tools/get_week_context ── reads Supabase directly ──────────────┤
+agent/tools/save_proposal ──▶ POST /api/agent/proposals (integrations)│
+                                  validates + writes draft batch      │
+admin board ── proposal banner, dashed "AI draft" cards, approve ─────┘
+```
+
+- The agent holds **no Momence credentials** and does **no schedule writes**
+  of its own: reads go straight to Supabase with a dedicated key; the one
+  write path is the integrations endpoint, which validates drafts with the
+  same parsers as manual edits and hard-rejects assignments over busy time
+  off. Shared pure logic (availability, hours, window math) lives in
+  `@pyre/schedule-core`.
+- Triggers: the board's "✦ Draft schedule" button (`POST
+  /api/admin/schedule-draft` → `POST {this app}/eve/v1/session`) and the
+  weekly schedule in `agent/schedules/weekly_draft.md` (Wed 14:00 UTC →
+  a Vercel Cron Job on deploy).
+- Re-drafting a week supersedes its open draft; accepted rows are never
+  touched.
+
+## Environment
+
+See `.env.example`. Key segmentation is per deployment boundary: one
+dedicated Supabase secret key for this whole app (`SUPABASE_AGENTS_SECRET_KEY`
+— mint it in the Supabase dashboard, revocable independently of
+integrations'), `AGENT_API_SECRET` for outbound writes to integrations,
+`EVE_CHANNEL_SECRET` for inbound session triggers. A future agent needing
+riskier access should graduate to its own Eve app + Vercel project.
+
+## Local dev (Node 24)
+
+```bash
+nvm use 24
+yarn workspace pyre-agents dev          # eve dev (schedules never auto-fire locally)
+```
+
+Point `INTEGRATIONS_BASE_URL` at a local integrations dev server. For evals
+without writing anything, set `AGENT_FORCE_DRY_RUN=1` and run
+`yarn workspace pyre-agents eval`.
+
+## Deploy checklist
+
+1. Migrations applied (`staff_scheduling`, `staff_scheduling_import`,
+   `schedule_proposals`): `yarn workspace @pyre/supabase migrate` locally,
+   `db:push` for prod.
+2. Mint the agents Supabase key; generate `AGENT_API_SECRET` and
+   `EVE_CHANNEL_SECRET` (e.g. `openssl rand -hex 32`).
+3. New Vercel project **pyre-agents**: Root Directory `apps/agents`, Node 24,
+   AI Gateway enabled, env vars from `.env.example`.
+4. pyre-integrations env additions: `AGENT_API_SECRET`, `AGENTS_BASE_URL`
+   (this app's deployment URL), `EVE_CHANNEL_SECRET`.
+5. Verify `GET /eve/v1/health`, then button-draft a future week from
+   `/admin/schedule`.
+6. The weekly cron registers automatically on deploy (check Vercel
+   Observability → Cron Jobs). If plan limits block Vercel Cron, delete
+   `agent/schedules/weekly_draft.md` and add a QStash schedule (or a
+   `CRON_JOBS` entry in integrations) POSTing the same `/eve/v1/session`
+   message the button sends.

--- a/apps/agents/agent/agent.ts
+++ b/apps/agents/agent/agent.ts
@@ -1,0 +1,8 @@
+import { defineAgent } from 'eve';
+
+// Model string routes through Vercel AI Gateway (OIDC on Vercel; local dev
+// needs AI_GATEWAY_API_KEY). Scheduling is judgment over a pre-computed
+// context, so the default reasoning settings are fine.
+export default defineAgent({
+  model: 'anthropic/claude-sonnet-5',
+});

--- a/apps/agents/agent/channels/eve.ts
+++ b/apps/agents/agent/channels/eve.ts
@@ -1,0 +1,28 @@
+// Inbound auth for the HTTP session API (POST /eve/v1/session): the
+// integrations app's "Draft schedule" endpoint calls with
+// `Authorization: Bearer ${EVE_CHANNEL_SECRET}`. Vercel OIDC covers CLI /
+// internal-deployment access; localDev keeps `eve dev` open locally.
+
+import { type AuthFn, extractBearerToken, localDev, vercelOidc } from 'eve/channels/auth';
+import { eveChannel } from 'eve/channels/eve';
+
+function channelSecretAuth(): AuthFn<Request> {
+  return (request) => {
+    const secret = process.env.EVE_CHANNEL_SECRET;
+    if (!secret) return null;
+
+    const token = extractBearerToken(request.headers.get('authorization'));
+    if (!token || token !== secret) return null;
+
+    return {
+      authenticator: 'channel-secret',
+      principalId: 'pyre-integrations',
+      principalType: 'service',
+      attributes: {},
+    };
+  };
+}
+
+export default eveChannel({
+  auth: [channelSecretAuth(), vercelOidc(), localDev()],
+});

--- a/apps/agents/agent/instructions.md
+++ b/apps/agents/agent/instructions.md
@@ -1,0 +1,49 @@
+You are Pyre Sauna's staff-scheduling drafter. Your job: draft one week of the
+staffing schedule as a proposal the admin reviews, edits, and approves on the
+admin board. You never publish a schedule — you only save drafts.
+
+## Workflow (always in this order)
+
+1. Call `get_week_context` for the requested week (default: next week). It
+   returns everything pre-computed: the roster, the week's shifts (coverage
+   windows already synced from Momence), existing accepted assignments, each
+   person's availability for each shift, recent weekly hours, and each
+   person's historical patterns.
+2. Decide who works each shift, then call `save_proposal` exactly once with
+   the complete draft. If it returns validation or conflict errors, fix them
+   and call it again until it succeeds.
+
+## Hard rules
+
+- NEVER assign someone over an availability of "busy" — the server rejects
+  the whole proposal if you do.
+- Never remove or change assignments that already exist (`existingAssignments`
+  in the context); schedule around them.
+- Every shift should reach its `staffNeeded` count. If that is impossible
+  with the available people, leave it short and call it out in the rationale.
+- Only propose extra shifts (beyond the synced coverage windows) when the
+  context shows a clear need (e.g. an uncovered flagged window); the admin
+  adds maintenance shifts themselves.
+
+## Judgment guidelines
+
+- Availability "partial" is usable when the person can cover most of the
+  window or a setup slot — note it in the rationale.
+- Balance weekly hours across the roster using `recentWeeklyHours`; avoid
+  loading one person far above their recent norm while others sit near zero.
+- Follow `historyPatterns`: people tend to keep their usual days, windows,
+  and setup-vs-full roles. Deviate when balance or availability requires it.
+- Use roles the way the history does: usually one or two "full" people per
+  shift plus a short "setup" hour at the start when the pattern shows it.
+- Assignment times default to the shift window; give a shorter window
+  (setup/partial) by setting startsAt/endsAt explicitly.
+
+## Rationale format
+
+Short markdown the admin skims on the board:
+
+- One bullet per day: who is on and anything notable.
+- A final **Tradeoffs** section: shifts left under-staffed and why, partial-
+  availability placements, hour-balance calls, pattern deviations.
+
+Keep it under ~25 lines. No preamble, no restating the schedule table.

--- a/apps/agents/agent/lib/api.ts
+++ b/apps/agents/agent/lib/api.ts
@@ -1,0 +1,30 @@
+// Server-to-server client for the integrations app's agent API (the write
+// path). Bearer AGENT_API_SECRET; see apps/integrations/src/lib/agent/auth.ts.
+
+export async function postProposal(body: Record<string, unknown>): Promise<{
+  status: number;
+  body: Record<string, unknown>;
+}> {
+  const baseUrl = process.env.INTEGRATIONS_BASE_URL;
+  const secret = process.env.AGENT_API_SECRET;
+  if (!baseUrl || !secret) {
+    throw new Error('Integrations API not configured (INTEGRATIONS_BASE_URL / AGENT_API_SECRET)');
+  }
+
+  const response = await fetch(`${baseUrl}/api/agent/proposals`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${secret}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = (await response.json()) as Record<string, unknown>;
+  } catch {
+    parsed = { error: `Non-JSON response (HTTP ${response.status})` };
+  }
+  return { status: response.status, body: parsed };
+}

--- a/apps/agents/agent/lib/db.ts
+++ b/apps/agents/agent/lib/db.ts
@@ -1,0 +1,23 @@
+// Supabase client for agent tools — READ ONLY by convention. This app holds
+// its own revocable secret key (SUPABASE_AGENTS_SECRET_KEY); all schedule
+// writes go through the integrations app's /api/agent/proposals endpoint so
+// validation and state transitions stay single-sourced.
+
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+let client: SupabaseClient | null | undefined;
+
+export function getDb(): SupabaseClient {
+  if (client) return client;
+
+  const url = process.env.SUPABASE_URL;
+  const secretKey = process.env.SUPABASE_AGENTS_SECRET_KEY;
+  if (!url || !secretKey) {
+    throw new Error('Supabase not configured (SUPABASE_URL / SUPABASE_AGENTS_SECRET_KEY)');
+  }
+
+  client = createClient(url, secretKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  return client;
+}

--- a/apps/agents/agent/schedules/weekly_draft.md
+++ b/apps/agents/agent/schedules/weekly_draft.md
@@ -1,0 +1,8 @@
+---
+cron: "0 14 * * 3"
+---
+
+Draft the staffing schedule for next week (the Monday after the coming
+weekend). Use get_week_context, then save exactly one proposal via
+save_proposal. If a previous draft exists for that week it will be superseded
+automatically — just draft fresh from the current context.

--- a/apps/agents/agent/tools/get_week_context.ts
+++ b/apps/agents/agent/tools/get_week_context.ts
@@ -1,0 +1,175 @@
+// The scheduler's entire world view, pre-computed: roster, the target week's
+// shifts (coverage windows already synced from Momence by the integrations
+// cron), accepted assignments, per-person availability for every shift,
+// recent weekly hours, and history patterns. All judgment-free math lives
+// here (via @pyre/schedule-core) so the model only decides who works when.
+
+import {
+  availabilityFor,
+  addDays,
+  rollupHours,
+  type ScheduleStaffRow,
+  type ShiftAssignmentRow,
+  type ShiftRow,
+  type TimeOffRow,
+  timeToMinutes,
+  utcToEastern,
+  weekStartOf,
+} from '@pyre/schedule-core';
+import { defineTool } from 'eve/tools';
+import { z } from 'zod';
+import { getDb } from '../lib/db';
+
+const HISTORY_WEEKS = 8;
+
+export default defineTool({
+  description:
+    'Load everything needed to draft one week of the staffing schedule: roster, shifts (coverage windows), accepted assignments, availability per person per shift, recent weekly hours, and history patterns. Call this first, before save_proposal.',
+  inputSchema: z.object({
+    weekStart: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/)
+      .optional()
+      .describe('Monday of the week to draft (YYYY-MM-DD). Defaults to next week.'),
+  }),
+  async execute({ weekStart: requestedWeekStart }) {
+    const db = getDb();
+
+    const todayEastern = utcToEastern(new Date().toISOString()).date;
+    const weekStart = requestedWeekStart
+      ? weekStartOf(requestedWeekStart)
+      : addDays(weekStartOf(todayEastern), 7);
+    const weekEnd = addDays(weekStart, 6);
+    const historyStart = addDays(weekStart, -7 * HISTORY_WEEKS);
+
+    const [staffRes, shiftsRes, timeOffRes] = await Promise.all([
+      db.from('schedule_staff').select('*').eq('active', true).order('display_name'),
+      db
+        .from('shifts')
+        .select('*')
+        .gte('shift_date', historyStart)
+        .lte('shift_date', weekEnd)
+        .eq('is_draft', false)
+        .order('shift_date'),
+      db.from('time_off').select('*'),
+    ]);
+    for (const res of [staffRes, shiftsRes, timeOffRes]) {
+      if (res.error) throw new Error(res.error.message);
+    }
+
+    const staff = (staffRes.data ?? []) as ScheduleStaffRow[];
+    const shifts = (shiftsRes.data ?? []) as ShiftRow[];
+    const timeOff = (timeOffRes.data ?? []) as TimeOffRow[];
+
+    const shiftIds = shifts.map((s) => s.id);
+    let assignments: ShiftAssignmentRow[] = [];
+    if (shiftIds.length > 0) {
+      const { data, error } = await db
+        .from('shift_assignments')
+        .select('*')
+        .in('shift_id', shiftIds)
+        .eq('is_draft', false);
+      if (error) throw new Error(error.message);
+      assignments = (data ?? []) as ShiftAssignmentRow[];
+    }
+
+    const shiftById = new Map(shifts.map((s) => [s.id, s]));
+    const weekShifts = shifts.filter(
+      (s) => s.shift_date >= weekStart && s.status === 'active'
+    );
+    const historyAssignments = assignments.filter((a) => {
+      const shift = shiftById.get(a.shift_id);
+      return shift !== undefined && shift.shift_date < weekStart;
+    });
+    const weekAssignments = assignments.filter((a) => {
+      const shift = shiftById.get(a.shift_id);
+      return shift !== undefined && shift.shift_date >= weekStart;
+    });
+
+    // Availability matrix: person × week shift.
+    const shiftsOut = weekShifts.map((shift) => ({
+      shiftId: shift.id,
+      date: shift.shift_date,
+      label: shift.label,
+      startsAt: shift.starts_at.slice(0, 5),
+      endsAt: shift.ends_at.slice(0, 5),
+      staffNeeded: shift.staff_needed,
+      notes: shift.notes,
+      syncFlag: shift.sync_flag,
+      availability: Object.fromEntries(
+        staff.map((person) => {
+          const result = availabilityFor(
+            timeOff,
+            person.id,
+            shift.shift_date,
+            timeToMinutes(shift.starts_at),
+            timeToMinutes(shift.ends_at)
+          );
+          return [
+            person.id,
+            {
+              status: result.status,
+              reasons: result.conflicts.map((c) => c.note || 'time off'),
+            },
+          ];
+        })
+      ),
+    }));
+
+    // Recent weekly hours (trailing history weeks, founders marked).
+    const founderIds = new Set(staff.filter((s) => s.is_founder).map((s) => s.id));
+    const weeks = rollupHours(
+      historyAssignments.map((assignment) => ({
+        assignment,
+        shiftDate: (shiftById.get(assignment.shift_id) as ShiftRow).shift_date,
+      })),
+      founderIds
+    );
+    const recentWeeklyHours = staff.map((person) => ({
+      staffId: person.id,
+      name: person.display_name,
+      isFounder: person.is_founder,
+      weekly: weeks.map((w) => ({
+        weekStart: w.weekStart,
+        hours: Math.round((w.byStaff[person.id] ?? 0) * 10) / 10,
+      })),
+    }));
+
+    // History patterns: per person, how often they worked each label/weekday
+    // and how often their assignments were setup vs full.
+    const historyPatterns = staff.map((person) => {
+      const theirs = historyAssignments.filter((a) => a.staff_id === person.id);
+      const byLabel: Record<string, number> = {};
+      const byWeekday: Record<string, number> = {};
+      const byRole: Record<string, number> = {};
+      for (const a of theirs) {
+        const shift = shiftById.get(a.shift_id) as ShiftRow;
+        byLabel[shift.label] = (byLabel[shift.label] ?? 0) + 1;
+        const weekday = new Date(`${shift.shift_date}T00:00:00Z`).getUTCDay();
+        byWeekday[String(weekday)] = (byWeekday[String(weekday)] ?? 0) + 1;
+        byRole[a.role] = (byRole[a.role] ?? 0) + 1;
+      }
+      return { staffId: person.id, name: person.display_name, byLabel, byWeekday, byRole };
+    });
+
+    return {
+      weekStart,
+      weekEnd,
+      staff: staff.map((s) => ({
+        staffId: s.id,
+        name: s.display_name,
+        isFounder: s.is_founder,
+      })),
+      shifts: shiftsOut,
+      existingAssignments: weekAssignments.map((a) => ({
+        shiftId: a.shift_id,
+        staffId: a.staff_id,
+        startsAt: a.starts_at.slice(0, 5),
+        endsAt: a.ends_at.slice(0, 5),
+        role: a.role,
+      })),
+      recentWeeklyHours,
+      historyPatterns,
+    };
+  },
+});

--- a/apps/agents/agent/tools/save_proposal.ts
+++ b/apps/agents/agent/tools/save_proposal.ts
@@ -1,0 +1,75 @@
+// Save the drafted week as a proposal batch via the integrations app (the
+// single validated write path). Server-side errors — including the hard
+// time-off conflict report — come back verbatim so the model can fix and
+// resubmit. AGENT_FORCE_DRY_RUN=1 (evals) validates without writing.
+
+import { defineTool } from 'eve/tools';
+import { z } from 'zod';
+import { postProposal } from '../lib/api';
+
+const timeString = z.string().regex(/^([01]\d|2[0-3]):[0-5]\d$/, 'HH:MM');
+const dateString = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'YYYY-MM-DD');
+
+export default defineTool({
+  description:
+    'Save the drafted schedule for one week as a proposal for admin review. Call exactly once per draft, after get_week_context. Assignments reference existing shifts by shiftId, or new shifts (in this payload) by shiftKey. On validation/conflict errors, fix the draft and call again.',
+  inputSchema: z.object({
+    weekStart: dateString.describe('Monday of the drafted week'),
+    rationale: z
+      .string()
+      .max(8000)
+      .describe('Short markdown for the admin: one bullet per day + a Tradeoffs section'),
+    summary: z
+      .object({
+        uncoveredShifts: z.number().int().min(0).default(0),
+        partialAvailabilityPlacements: z.number().int().min(0).default(0),
+        warnings: z.array(z.string()).default([]),
+      })
+      .describe('Machine-readable counts and warnings shown as badges'),
+    shifts: z
+      .array(
+        z.object({
+          key: z.string().min(1).describe('Payload-local key assignments can reference'),
+          shiftDate: dateString,
+          label: z.string().min(1).max(40),
+          startsAt: timeString,
+          endsAt: timeString,
+          staffNeeded: z.number().int().min(0).max(20),
+          notes: z.string().max(500).nullish(),
+        })
+      )
+      .default([])
+      .describe('Extra shifts beyond the synced coverage windows (usually empty)'),
+    assignments: z
+      .array(
+        z.object({
+          shiftId: z.string().nullish().describe('Existing shift id (from get_week_context)'),
+          shiftKey: z.string().nullish().describe("A new shift's key from this payload"),
+          staffId: z.string().min(1),
+          startsAt: timeString.nullish().describe('Defaults to the shift window'),
+          endsAt: timeString.nullish(),
+          role: z.enum(['full', 'setup', 'partial']).default('full'),
+          notes: z.string().max(500).nullish(),
+        })
+      )
+      .min(1),
+  }),
+  async execute(input, ctx) {
+    const { status, body } = await postProposal({
+      ...input,
+      source: 'manual',
+      agentSessionId: ctx.session?.id ?? null,
+      dryRun: process.env.AGENT_FORCE_DRY_RUN === '1',
+    });
+
+    if (status >= 400) {
+      return {
+        saved: false,
+        status,
+        error: body.error ?? 'Unknown error',
+        conflicts: body.conflicts ?? [],
+      };
+    }
+    return { saved: true, ...body };
+  },
+});

--- a/apps/agents/evals/draft-week.eval.ts
+++ b/apps/agents/evals/draft-week.eval.ts
@@ -1,0 +1,23 @@
+// Offline draft-week eval: run against `eve dev` with INTEGRATIONS_BASE_URL
+// pointed at a local integrations dev server (local Supabase seeded by the
+// staff_scheduling migrations) and AGENT_FORCE_DRY_RUN=1 so save_proposal
+// validates without writing. The dry-run response carries the server-side
+// conflict report, which is the ground truth the checks lean on.
+
+import { defineEval } from 'eve/evals';
+
+export default defineEval({
+  description: 'Drafts next week: context first, one proposal save, clean conflict report',
+  async test(t) {
+    await t.send('Draft the staffing schedule for next week.');
+
+    t.toolOrder(['get_week_context', 'save_proposal']);
+    t.calledTool('save_proposal');
+    t.maxToolCalls(6);
+    t.noFailedActions();
+
+    t.judge.autoevals.closedQA(
+      'The assistant reports the draft was saved (or dry-run validated) with no hard availability conflicts, and its summary mentions any shifts left under-staffed.'
+    );
+  },
+});

--- a/apps/agents/evals/evals.config.ts
+++ b/apps/agents/evals/evals.config.ts
@@ -1,0 +1,6 @@
+import { defineEvalConfig } from 'eve/evals';
+
+// LLM-judge checks (rationale quality) also route through AI Gateway.
+export default defineEvalConfig({
+  judge: { model: 'anthropic/claude-sonnet-5' },
+});

--- a/apps/agents/package.json
+++ b/apps/agents/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "pyre-agents",
+  "version": "0.0.1",
+  "type": "module",
+  "private": true,
+  "description": "Eve agent app for Pyre: the staff-scheduling drafter (first of the agent use cases). Reads Supabase directly; writes proposals through the integrations app.",
+  "engines": {
+    "node": ">=24"
+  },
+  "scripts": {
+    "dev": "eve dev",
+    "build": "echo 'pyre-agents builds via eve on Vercel (yarn build:eve locally)'",
+    "build:eve": "eve build",
+    "eval": "eve eval",
+    "test": "echo 'evals run via yarn eval against a dev server'"
+  },
+  "dependencies": {
+    "@pyre/schedule-core": "workspace:^",
+    "@supabase/supabase-js": "^2.110.5",
+    "ai": "7.0.34",
+    "eve": "0.27.0",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apps/agents/tsconfig.json
+++ b/apps/agents/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "include": ["agent/**/*", "evals/**/*"],
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "lib": ["es2022"],
+    "types": ["node"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true
+  }
+}

--- a/packages/schedule-core/package.json
+++ b/packages/schedule-core/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@pyre/schedule-core",
+  "version": "0.0.1",
+  "type": "module",
+  "private": true,
+  "description": "Pure staff-scheduling logic shared by the integrations app and the agents app: availability engine, hours rollup, Momence coverage-window derivation, and the schedule row types.",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@types/node": "^22.20.1",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.10"
+  }
+}

--- a/packages/schedule-core/src/availability.ts
+++ b/packages/schedule-core/src/availability.ts
@@ -1,0 +1,146 @@
+// Availability engine: expands time_off rows (trip ranges + recurring weekly
+// patterns, optionally time-bounded) into concrete busy intervals for a given
+// date, and classifies whether someone is free for a shift window. Pure
+// functions over plain data — used server-side by the API routes and locally
+// by the admin islands (same pattern as lib/water/recommendations), and
+// pinned down in availability.test.ts.
+//
+// All dates are local YYYY-MM-DD strings and all times are local wall-clock
+// 'HH:MM' / 'HH:MM:SS' strings; nothing here touches Date.now() or timezones
+// beyond deriving the weekday of a calendar date.
+
+import type { ShiftAssignmentRow, TimeOffRow } from './types';
+
+export const DAY_START_MIN = 0;
+export const DAY_END_MIN = 24 * 60;
+
+/** 'HH:MM' or 'HH:MM:SS' → minutes since midnight. */
+export function timeToMinutes(time: string): number {
+  const [h, m] = time.split(':');
+  return Number.parseInt(h, 10) * 60 + Number.parseInt(m, 10);
+}
+
+/** Minutes since midnight → 'HH:MM'. */
+export function minutesToTime(minutes: number): string {
+  const h = Math.floor(minutes / 60) % 24;
+  const m = minutes % 60;
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+}
+
+/** Weekday of a YYYY-MM-DD calendar date: 0 = Sunday .. 6 = Saturday. */
+export function dayOfWeek(date: string): number {
+  // Parse as UTC so the host machine's timezone can't shift the calendar day.
+  return new Date(`${date}T00:00:00Z`).getUTCDay();
+}
+
+export interface BusyInterval {
+  startMin: number;
+  endMin: number;
+  /** True when the entry has no time bounds — unavailable the whole day. */
+  wholeDay: boolean;
+  note: string | null;
+  timeOffId: string;
+}
+
+/** The busy interval `entry` contributes on `date`, or null if it doesn't apply. */
+export function busyIntervalOn(entry: TimeOffRow, date: string): BusyInterval | null {
+  if (entry.kind === 'range') {
+    if (!entry.start_date || !entry.end_date) return null;
+    if (date < entry.start_date || date > entry.end_date) return null;
+  } else {
+    if (!entry.days_of_week.includes(dayOfWeek(date))) return null;
+    if (entry.start_date && date < entry.start_date) return null;
+    if (entry.end_date && date > entry.end_date) return null;
+  }
+
+  const wholeDay = entry.starts_at == null || entry.ends_at == null;
+  return {
+    startMin: wholeDay ? DAY_START_MIN : timeToMinutes(entry.starts_at as string),
+    endMin: wholeDay ? DAY_END_MIN : timeToMinutes(entry.ends_at as string),
+    wholeDay,
+    note: entry.note,
+    timeOffId: entry.id,
+  };
+}
+
+/** All busy intervals for one staff member on one date. */
+export function busyIntervalsFor(
+  entries: TimeOffRow[],
+  staffId: string,
+  date: string
+): BusyInterval[] {
+  const intervals: BusyInterval[] = [];
+  for (const entry of entries) {
+    if (entry.staff_id !== staffId) continue;
+    const interval = busyIntervalOn(entry, date);
+    if (interval) intervals.push(interval);
+  }
+  return intervals;
+}
+
+export type AvailabilityStatus = 'free' | 'partial' | 'busy';
+
+export interface Availability {
+  status: AvailabilityStatus;
+  /** The busy intervals that overlap the window (empty when free). */
+  conflicts: BusyInterval[];
+}
+
+/**
+ * Classify a staff member's availability for a window on a date:
+ * 'busy' when busy intervals cover the whole window, 'partial' when they
+ * overlap part of it, 'free' otherwise. Interval ends are exclusive, so
+ * time off ending 14:30 doesn't conflict with a shift starting 14:30.
+ */
+export function availabilityFor(
+  entries: TimeOffRow[],
+  staffId: string,
+  date: string,
+  startMin: number,
+  endMin: number
+): Availability {
+  const overlapping = busyIntervalsFor(entries, staffId, date).filter(
+    (b) => b.startMin < endMin && b.endMin > startMin
+  );
+  if (overlapping.length === 0) return { status: 'free', conflicts: [] };
+
+  // Walk merged coverage to see whether the window is fully covered.
+  const sorted = [...overlapping].sort((a, b) => a.startMin - b.startMin);
+  let covered = startMin;
+  for (const b of sorted) {
+    if (b.startMin > covered) break;
+    covered = Math.max(covered, b.endMin);
+  }
+
+  return { status: covered >= endMin ? 'busy' : 'partial', conflicts: overlapping };
+}
+
+export interface AssignmentConflict {
+  assignment: ShiftAssignmentRow;
+  shiftDate: string;
+  conflicts: BusyInterval[];
+}
+
+/**
+ * Assignments that overlap the assignee's time off — surfaced as warnings in
+ * the admin UI (time off auto-approves; nothing is unassigned automatically).
+ */
+export function findAssignmentConflicts(
+  assignments: Array<{ assignment: ShiftAssignmentRow; shiftDate: string }>,
+  entries: TimeOffRow[]
+): AssignmentConflict[] {
+  const result: AssignmentConflict[] = [];
+  for (const { assignment, shiftDate } of assignments) {
+    const availability = availabilityFor(
+      entries,
+      assignment.staff_id,
+      shiftDate,
+      timeToMinutes(assignment.starts_at),
+      timeToMinutes(assignment.ends_at)
+    );
+    if (availability.status !== 'free') {
+      result.push({ assignment, shiftDate, conflicts: availability.conflicts });
+    }
+  }
+  return result;
+}

--- a/packages/schedule-core/src/constants.ts
+++ b/packages/schedule-core/src/constants.ts
@@ -1,0 +1,27 @@
+// Shared vocabulary for the staff scheduling feature (see
+// docs/staff-scheduling-scope.md). Mirrors the check constraints in the
+// staff_scheduling migration.
+
+export const ASSIGNMENT_ROLES = ['full', 'setup', 'partial'] as const;
+export type AssignmentRole = (typeof ASSIGNMENT_ROLES)[number];
+
+export const ASSIGNMENT_ROLE_LABELS: Record<AssignmentRole, string> = {
+  full: 'Full',
+  setup: 'Setup',
+  partial: 'Partial',
+};
+
+export const TIME_OFF_KINDS = ['range', 'recurring'] as const;
+export type TimeOffKind = (typeof TIME_OFF_KINDS)[number];
+
+/** Index = JS Date.getDay(): 0 = Sunday .. 6 = Saturday. */
+export const DOW_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;
+
+/** Window names the sheet used; the label field stays free text for ad-hoc shifts. */
+export const SHIFT_LABEL_SUGGESTIONS = [
+  'Morning',
+  'Day',
+  'Afternoon',
+  'Evening',
+  'Maintenance',
+] as const;

--- a/packages/schedule-core/src/hours.ts
+++ b/packages/schedule-core/src/hours.ts
@@ -1,0 +1,104 @@
+// Hours rollup for the /admin/schedule/hours report — per-person hours by
+// date and by week, plus the sheet's "% founders" coverage metric. Weeks run
+// Monday–Sunday. Pure functions, pinned down in hours.test.ts.
+
+import type { ScheduleStaffRow, ShiftAssignmentRow } from './types';
+import { timeToMinutes } from './availability';
+
+export function assignmentHours(startsAt: string, endsAt: string): number {
+  return (timeToMinutes(endsAt) - timeToMinutes(startsAt)) / 60;
+}
+
+/** Monday of the week containing a YYYY-MM-DD date, as YYYY-MM-DD. */
+export function weekStartOf(date: string): string {
+  const d = new Date(`${date}T00:00:00Z`);
+  const dow = d.getUTCDay(); // 0 = Sunday
+  const daysSinceMonday = (dow + 6) % 7;
+  d.setUTCDate(d.getUTCDate() - daysSinceMonday);
+  return d.toISOString().slice(0, 10);
+}
+
+export function addDays(date: string, days: number): string {
+  const d = new Date(`${date}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+export interface DayHours {
+  date: string;
+  byStaff: Record<string, number>;
+  total: number;
+}
+
+export interface WeekHours {
+  /** Monday, YYYY-MM-DD. */
+  weekStart: string;
+  days: DayHours[];
+  byStaff: Record<string, number>;
+  total: number;
+  /** Share of the week's hours worked by founders (0..1); null when no hours. */
+  founderShare: number | null;
+}
+
+/**
+ * Group assignments into Monday–Sunday weeks with per-day and per-week hours
+ * per staff id. `founderIds` drives the % founders metric.
+ */
+export function rollupHours(
+  assignments: Array<{ assignment: ShiftAssignmentRow; shiftDate: string }>,
+  founderIds: Set<string>
+): WeekHours[] {
+  const weeks = new Map<string, Map<string, Record<string, number>>>();
+
+  for (const { assignment, shiftDate } of assignments) {
+    const week = weekStartOf(shiftDate);
+    let days = weeks.get(week);
+    if (!days) {
+      days = new Map();
+      weeks.set(week, days);
+    }
+    let byStaff = days.get(shiftDate);
+    if (!byStaff) {
+      byStaff = {};
+      days.set(shiftDate, byStaff);
+    }
+    byStaff[assignment.staff_id] =
+      (byStaff[assignment.staff_id] ?? 0) +
+      assignmentHours(assignment.starts_at, assignment.ends_at);
+  }
+
+  return [...weeks.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([weekStart, dayMap]) => {
+      const days: DayHours[] = [...dayMap.entries()]
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([date, byStaff]) => ({
+          date,
+          byStaff,
+          total: Object.values(byStaff).reduce((a, b) => a + b, 0),
+        }));
+
+      const byStaff: Record<string, number> = {};
+      for (const day of days) {
+        for (const [staffId, hours] of Object.entries(day.byStaff)) {
+          byStaff[staffId] = (byStaff[staffId] ?? 0) + hours;
+        }
+      }
+      const total = Object.values(byStaff).reduce((a, b) => a + b, 0);
+      const founderHours = Object.entries(byStaff)
+        .filter(([staffId]) => founderIds.has(staffId))
+        .reduce((a, [, hours]) => a + hours, 0);
+
+      return {
+        weekStart,
+        days,
+        byStaff,
+        total,
+        founderShare: total > 0 ? founderHours / total : null,
+      };
+    });
+}
+
+export function founderIdsOf(staff: ScheduleStaffRow[]): Set<string> {
+  return new Set(staff.filter((s) => s.is_founder).map((s) => s.id));
+}

--- a/packages/schedule-core/src/index.ts
+++ b/packages/schedule-core/src/index.ts
@@ -1,0 +1,6 @@
+export * from './types';
+export * from './constants';
+export * from './availability';
+export * from './hours';
+export * from './windows';
+export * from './tz';

--- a/packages/schedule-core/src/types.ts
+++ b/packages/schedule-core/src/types.ts
@@ -1,0 +1,84 @@
+// Row shapes for the staff-scheduling tables (see the staff_scheduling and
+// schedule_proposals migrations in apps/supabase). Dates are YYYY-MM-DD and
+// times are local wall-clock 'HH:MM' / 'HH:MM:SS' strings — America/New_York,
+// never UTC. Shared by apps/integrations (which re-exports them from lib/db)
+// and apps/agents.
+
+export interface ScheduleStaffRow {
+  id: string;
+  display_name: string;
+  /** Join key against the Momence OAuth profile email; null until confirmed. */
+  momence_email: string | null;
+  role: 'admin' | 'staff';
+  is_founder: boolean;
+  active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ShiftRow {
+  id: string;
+  shift_date: string;
+  label: string;
+  starts_at: string;
+  ends_at: string;
+  staff_needed: number;
+  source: 'momence' | 'manual';
+  momence_session_ids: Array<{ type: string; id: number }>;
+  sync_locked: boolean;
+  notes: string | null;
+  status: 'active' | 'cancelled';
+  /** Set when this row belongs (or belonged) to an agent draft batch. */
+  proposal_id: string | null;
+  /** Draft rows are only visible to the review UI until approved. */
+  is_draft: boolean;
+  /** Momence divergence the sync couldn't silently fix — needs admin eyes. */
+  sync_flag: 'sessions_cancelled' | 'times_changed' | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ShiftAssignmentRow {
+  id: string;
+  shift_id: string;
+  staff_id: string;
+  starts_at: string;
+  ends_at: string;
+  role: 'full' | 'setup' | 'partial';
+  notes: string | null;
+  proposal_id: string | null;
+  is_draft: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface TimeOffRow {
+  id: string;
+  staff_id: string;
+  kind: 'range' | 'recurring';
+  start_date: string | null;
+  end_date: string | null;
+  /** 0 = Sunday .. 6 = Saturday (matches JS Date.getDay()). */
+  days_of_week: number[];
+  starts_at: string | null;
+  ends_at: string | null;
+  note: string | null;
+  created_by: 'staff' | 'admin';
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ScheduleProposalRow {
+  id: string;
+  /** Monday of the drafted week. */
+  week_start: string;
+  status: 'draft' | 'approved' | 'superseded' | 'discarded';
+  /** Agent's markdown summary shown on the board. */
+  rationale: string | null;
+  summary: Record<string, unknown>;
+  source: 'cron' | 'manual';
+  agent_session_id: string | null;
+  decided_at: string | null;
+  created_at: string;
+  updated_at: string;
+}

--- a/packages/schedule-core/src/tz.ts
+++ b/packages/schedule-core/src/tz.ts
@@ -1,0 +1,31 @@
+// UTC → America/New_York wall-clock conversion for Momence timestamps. Uses
+// Intl (no dependency); DST is handled by the timezone database.
+
+const ET_FORMAT = new Intl.DateTimeFormat('en-CA', {
+  timeZone: 'America/New_York',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+});
+
+export interface LocalWallClock {
+  /** YYYY-MM-DD in America/New_York. */
+  date: string;
+  /** Minutes since local midnight. */
+  minutes: number;
+}
+
+/** Convert a UTC ISO timestamp (e.g. Momence startsAt) to ET wall-clock. */
+export function utcToEastern(iso: string): LocalWallClock {
+  const parts = ET_FORMAT.formatToParts(new Date(iso));
+  const get = (type: string) => parts.find((p) => p.type === type)?.value ?? '00';
+  // en-CA hour can render midnight as '24'; normalize.
+  const hour = Number.parseInt(get('hour'), 10) % 24;
+  return {
+    date: `${get('year')}-${get('month')}-${get('day')}`,
+    minutes: hour * 60 + Number.parseInt(get('minute'), 10),
+  };
+}

--- a/packages/schedule-core/src/windows.ts
+++ b/packages/schedule-core/src/windows.ts
@@ -1,0 +1,209 @@
+// Coverage-window derivation: turn the day's Momence sessions and private
+// appointments into staffing shift windows, and diff those windows against
+// the shifts already in the database so the sync can create/update/cancel/
+// flag without ever silently changing staffed work. Pure functions — the
+// Momence fetch and the DB writes live in apps/integrations.
+
+import { minutesToTime, timeToMinutes } from './availability';
+
+export interface CoverageEvent {
+  kind: 'session' | 'appointment';
+  id: number;
+  title: string;
+  /** Local ET wall-clock (converted from Momence UTC before this layer). */
+  date: string;
+  startMin: number;
+  endMin: number;
+}
+
+export interface WindowOptions {
+  /** Staff arrive this many minutes before the first session. */
+  leadMin: number;
+  /** Staff stay this many minutes after the last session. */
+  closeMin: number;
+  /** Sessions closer together than this share one window. */
+  mergeGapMin: number;
+  defaultStaffNeeded: number;
+}
+
+export const DEFAULT_WINDOW_OPTIONS: WindowOptions = {
+  leadMin: 60,
+  closeMin: 30,
+  mergeGapMin: 90,
+  defaultStaffNeeded: 2,
+};
+
+export interface CoverageWindow {
+  date: string;
+  startMin: number;
+  endMin: number;
+  label: string;
+  staffNeeded: number;
+  sessionRefs: Array<{ type: 'session' | 'appointment'; id: number }>;
+  /** Titles of the covered events, for shift notes/debugging. */
+  titles: string[];
+}
+
+const DAY_MIN = 24 * 60;
+
+/** Round outward to :00/:30 so windows look like human-made shifts. */
+const floorHalfHour = (min: number) => Math.floor(min / 30) * 30;
+const ceilHalfHour = (min: number) => Math.ceil(min / 30) * 30;
+
+/** Label heuristic matching the sheet's vocabulary; admins can rename. */
+export function labelForWindow(startMin: number, endMin: number): string {
+  const startHour = startMin / 60;
+  if (startHour < 10) return endMin - startMin > 6 * 60 ? 'Day' : 'Morning';
+  if (startHour < 13.5) return 'Afternoon';
+  return 'Evening';
+}
+
+/**
+ * Merge a date-sorted set of events into padded coverage windows. Events on
+ * different dates never merge.
+ */
+export function deriveCoverageWindows(
+  events: CoverageEvent[],
+  options: WindowOptions = DEFAULT_WINDOW_OPTIONS
+): CoverageWindow[] {
+  const byDate = new Map<string, CoverageEvent[]>();
+  for (const event of events) {
+    const list = byDate.get(event.date) ?? [];
+    list.push(event);
+    byDate.set(event.date, list);
+  }
+
+  const windows: CoverageWindow[] = [];
+  for (const [date, dayEvents] of [...byDate.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+    const sorted = [...dayEvents].sort((a, b) => a.startMin - b.startMin);
+    let current: CoverageWindow | null = null;
+    let currentPaddedEnd = 0;
+
+    for (const event of sorted) {
+      const paddedStart = Math.max(0, event.startMin - options.leadMin);
+      const paddedEnd = Math.min(DAY_MIN, event.endMin + options.closeMin);
+
+      if (current && paddedStart <= currentPaddedEnd + options.mergeGapMin) {
+        currentPaddedEnd = Math.max(currentPaddedEnd, paddedEnd);
+        current.endMin = ceilHalfHour(currentPaddedEnd);
+        current.sessionRefs.push({ type: event.kind, id: event.id });
+        current.titles.push(event.title);
+      } else {
+        current = {
+          date,
+          startMin: floorHalfHour(paddedStart),
+          endMin: ceilHalfHour(paddedEnd),
+          label: '',
+          staffNeeded: options.defaultStaffNeeded,
+          sessionRefs: [{ type: event.kind, id: event.id }],
+          titles: [event.title],
+        };
+        currentPaddedEnd = paddedEnd;
+        windows.push(current);
+      }
+    }
+
+    for (const window of windows) {
+      if (window.date === date && !window.label) {
+        window.label = labelForWindow(window.startMin, window.endMin);
+      }
+    }
+  }
+
+  return windows;
+}
+
+// --- Sync planning: diff derived windows against existing shifts ---
+
+/** The slice of a shifts row (plus assignment count) the planner needs. */
+export interface SyncShiftInput {
+  id: string;
+  shift_date: string;
+  starts_at: string;
+  ends_at: string;
+  source: 'momence' | 'manual';
+  momence_session_ids: Array<{ type: string; id: number }>;
+  sync_locked: boolean;
+  status: 'active' | 'cancelled';
+  sync_flag: 'sessions_cancelled' | 'times_changed' | null;
+  is_draft: boolean;
+  assignmentCount: number;
+}
+
+export interface SyncPlan {
+  create: CoverageWindow[];
+  /** Unlocked momence shifts whose window moved — safe in-place updates. */
+  update: Array<{ shiftId: string; startsAt: string; endsAt: string; sessionRefs: CoverageWindow['sessionRefs'] }>;
+  /** Unassigned, unlocked momence shifts whose sessions all disappeared. */
+  cancel: Array<{ shiftId: string; reason: string }>;
+  /** Divergence on staffed/locked shifts — admin decides, nothing auto-changes. */
+  flag: Array<{ shiftId: string; flag: 'sessions_cancelled' | 'times_changed' }>;
+  /** Previously-flagged shifts whose divergence resolved. */
+  clearFlag: string[];
+}
+
+const refKey = (ref: { type: string; id: number }) => `${ref.type}:${ref.id}`;
+
+/**
+ * Plan the sync for one horizon: match derived windows to existing
+ * momence-sourced shifts (session-ref overlap first, then time overlap),
+ * then classify every difference. Manual and draft shifts are never touched.
+ */
+export function planShiftSync(windows: CoverageWindow[], existing: SyncShiftInput[]): SyncPlan {
+  const plan: SyncPlan = { create: [], update: [], cancel: [], flag: [], clearFlag: [] };
+  const candidates = existing.filter((s) => s.source === 'momence' && !s.is_draft);
+  const matchedShiftIds = new Set<string>();
+
+  for (const window of windows) {
+    const windowRefs = new Set(window.sessionRefs.map(refKey));
+    const sameDay = candidates.filter(
+      (s) => s.shift_date === window.date && !matchedShiftIds.has(s.id)
+    );
+
+    let match =
+      sameDay.find((s) => s.momence_session_ids.some((ref) => windowRefs.has(refKey(ref)))) ??
+      sameDay.find(
+        (s) =>
+          timeToMinutes(s.starts_at) < window.endMin && timeToMinutes(s.ends_at) > window.startMin
+      );
+
+    if (!match) {
+      plan.create.push(window);
+      continue;
+    }
+    matchedShiftIds.add(match.id);
+
+    const startsAt = minutesToTime(window.startMin);
+    const endsAt = minutesToTime(window.endMin);
+    const timesMatch =
+      timeToMinutes(match.starts_at) === window.startMin &&
+      timeToMinutes(match.ends_at) === window.endMin;
+    const refsMatch =
+      match.momence_session_ids.length === window.sessionRefs.length &&
+      match.momence_session_ids.every((ref) => windowRefs.has(refKey(ref)));
+
+    if (timesMatch && refsMatch) {
+      if (match.sync_flag) plan.clearFlag.push(match.id);
+      continue;
+    }
+    if (match.sync_locked) {
+      if (!timesMatch && match.sync_flag !== 'times_changed') {
+        plan.flag.push({ shiftId: match.id, flag: 'times_changed' });
+      }
+      continue;
+    }
+    plan.update.push({ shiftId: match.id, startsAt, endsAt, sessionRefs: window.sessionRefs });
+  }
+
+  // Shifts whose sessions all disappeared (deleted or cancelled in Momence).
+  for (const shift of candidates) {
+    if (matchedShiftIds.has(shift.id) || shift.status === 'cancelled') continue;
+    if (shift.assignmentCount === 0 && !shift.sync_locked) {
+      plan.cancel.push({ shiftId: shift.id, reason: 'Momence sessions removed' });
+    } else if (shift.sync_flag !== 'sessions_cancelled') {
+      plan.flag.push({ shiftId: shift.id, flag: 'sessions_cancelled' });
+    }
+  }
+
+  return plan;
+}

--- a/packages/schedule-core/test/availability.test.ts
+++ b/packages/schedule-core/test/availability.test.ts
@@ -1,0 +1,198 @@
+// The availability engine is what stops someone getting scheduled during time
+// off the sheet used to require checking by hand (especially the time-bounded
+// recurring rules) — so the sheet's real blackout shapes are pinned here.
+
+import { describe, expect, it } from 'vitest';
+import type { TimeOffRow } from '../src/types';
+import {
+  availabilityFor,
+  busyIntervalOn,
+  dayOfWeek,
+  findAssignmentConflicts,
+  minutesToTime,
+  timeToMinutes,
+} from '../src/availability';
+
+const STAFF = 'staff-1';
+
+function entry(partial: Partial<TimeOffRow>): TimeOffRow {
+  return {
+    id: 'to-1',
+    staff_id: STAFF,
+    kind: 'range',
+    start_date: null,
+    end_date: null,
+    days_of_week: [],
+    starts_at: null,
+    ends_at: null,
+    note: null,
+    created_by: 'admin',
+    created_at: '',
+    updated_at: '',
+    ...partial,
+  };
+}
+
+describe('time helpers', () => {
+  it('parses HH:MM and HH:MM:SS', () => {
+    expect(timeToMinutes('14:30')).toBe(870);
+    expect(timeToMinutes('14:30:00')).toBe(870);
+    expect(timeToMinutes('00:00')).toBe(0);
+  });
+
+  it('formats minutes back to HH:MM', () => {
+    expect(minutesToTime(870)).toBe('14:30');
+    expect(minutesToTime(0)).toBe('00:00');
+  });
+
+  it('gets the weekday of a calendar date regardless of host timezone', () => {
+    expect(dayOfWeek('2026-08-09')).toBe(0); // a Sunday
+    expect(dayOfWeek('2026-08-10')).toBe(1); // a Monday
+  });
+});
+
+describe('busyIntervalOn', () => {
+  it('applies a trip range on every day within it, inclusive of both ends', () => {
+    const trip = entry({ kind: 'range', start_date: '2026-08-05', end_date: '2026-08-09' });
+    expect(busyIntervalOn(trip, '2026-08-04')).toBeNull();
+    expect(busyIntervalOn(trip, '2026-08-05')).toMatchObject({ wholeDay: true });
+    expect(busyIntervalOn(trip, '2026-08-09')).toMatchObject({ wholeDay: true });
+    expect(busyIntervalOn(trip, '2026-08-10')).toBeNull();
+  });
+
+  it('applies a recurring rule only on its weekdays', () => {
+    // Omar: no Sundays
+    const rule = entry({ kind: 'recurring', days_of_week: [0] });
+    expect(busyIntervalOn(rule, '2026-08-09')).toMatchObject({ wholeDay: true }); // Sunday
+    expect(busyIntervalOn(rule, '2026-08-10')).toBeNull(); // Monday
+  });
+
+  it('bounds a recurring rule by its start/end dates', () => {
+    // Sunny: Mon/Wed/Fri mornings, Aug 18 – Dec 7
+    const rule = entry({
+      kind: 'recurring',
+      days_of_week: [1, 3, 5],
+      start_date: '2026-08-18',
+      end_date: '2026-12-07',
+      starts_at: '00:00',
+      ends_at: '12:00',
+    });
+    expect(busyIntervalOn(rule, '2026-08-14')).toBeNull(); // Friday before bounds
+    expect(busyIntervalOn(rule, '2026-08-19')).toMatchObject({
+      // Wednesday inside
+      startMin: 0,
+      endMin: 720,
+      wholeDay: false,
+    });
+    expect(busyIntervalOn(rule, '2026-12-09')).toBeNull(); // Wednesday after bounds
+  });
+});
+
+describe('availabilityFor', () => {
+  const evening = [timeToMinutes('14:30'), timeToMinutes('20:30')] as const;
+
+  it('is free with no entries', () => {
+    expect(availabilityFor([], STAFF, '2026-08-13', ...evening).status).toBe('free');
+  });
+
+  it('ignores other staff members’ entries', () => {
+    const trip = entry({ kind: 'range', start_date: '2026-08-13', end_date: '2026-08-13' });
+    expect(availabilityFor([trip], 'staff-2', '2026-08-13', ...evening).status).toBe('free');
+  });
+
+  it('flags a partial overlap the sheet could only mark "check manually"', () => {
+    // Sarah: Thursdays 17:30–21:00 → evening shift 14:30–20:30 is partially blocked
+    const rule = entry({
+      kind: 'recurring',
+      days_of_week: [4],
+      start_date: '2026-08-06',
+      end_date: '2026-11-22',
+      starts_at: '17:30',
+      ends_at: '21:00',
+    });
+    const result = availabilityFor([rule], STAFF, '2026-08-13', ...evening); // a Thursday
+    expect(result.status).toBe('partial');
+    expect(result.conflicts).toHaveLength(1);
+  });
+
+  it('is busy when the window is fully covered', () => {
+    const trip = entry({ kind: 'range', start_date: '2026-08-13', end_date: '2026-08-13' });
+    expect(availabilityFor([trip], STAFF, '2026-08-13', ...evening).status).toBe('busy');
+  });
+
+  it('treats interval ends as exclusive — time off ending at shift start is fine', () => {
+    const rule = entry({
+      kind: 'recurring',
+      days_of_week: [4],
+      starts_at: '10:30',
+      ends_at: '14:30',
+    });
+    expect(availabilityFor([rule], STAFF, '2026-08-13', ...evening).status).toBe('free');
+  });
+
+  it('is busy when two touching intervals jointly cover the window', () => {
+    const morning = entry({
+      id: 'to-a',
+      kind: 'recurring',
+      days_of_week: [4],
+      starts_at: '00:00',
+      ends_at: '17:00',
+    });
+    const eveningRule = entry({
+      id: 'to-b',
+      kind: 'recurring',
+      days_of_week: [4],
+      starts_at: '17:00',
+      ends_at: '23:30',
+    });
+    const result = availabilityFor([morning, eveningRule], STAFF, '2026-08-13', ...evening);
+    expect(result.status).toBe('busy');
+    expect(result.conflicts).toHaveLength(2);
+  });
+
+  it('is partial when intervals overlap but leave a gap in the window', () => {
+    const early = entry({
+      id: 'to-a',
+      kind: 'recurring',
+      days_of_week: [4],
+      starts_at: '00:00',
+      ends_at: '16:00',
+    });
+    const late = entry({
+      id: 'to-b',
+      kind: 'recurring',
+      days_of_week: [4],
+      starts_at: '18:00',
+      ends_at: '23:30',
+    });
+    expect(availabilityFor([early, late], STAFF, '2026-08-13', ...evening).status).toBe('partial');
+  });
+});
+
+describe('findAssignmentConflicts', () => {
+  it('flags assignments that overlap time off, and only those', () => {
+    const trip = entry({ kind: 'range', start_date: '2026-08-07', end_date: '2026-08-09' });
+    const make = (id: string, date: string) => ({
+      shiftDate: date,
+      assignment: {
+        id,
+        shift_id: 'shift-1',
+        staff_id: STAFF,
+        starts_at: '14:30:00',
+        ends_at: '20:30:00',
+        role: 'full' as const,
+        notes: null,
+        proposal_id: null,
+        is_draft: false,
+        created_at: '',
+        updated_at: '',
+      },
+    });
+    const conflicts = findAssignmentConflicts(
+      [make('a', '2026-08-06'), make('b', '2026-08-08')],
+      [trip]
+    );
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].assignment.id).toBe('b');
+  });
+});

--- a/packages/schedule-core/test/hours.test.ts
+++ b/packages/schedule-core/test/hours.test.ts
@@ -1,0 +1,108 @@
+// Hours rollup: verified against the sheet's own "Total Hours" numbers for
+// the week of Jul 8–12, 2026 (including the 0.759 "% founders" cell).
+
+import { describe, expect, it } from 'vitest';
+import type { ShiftAssignmentRow } from '../src/types';
+import { addDays, assignmentHours, rollupHours, weekStartOf } from '../src/hours';
+
+function assignment(
+  staffId: string,
+  shiftDate: string,
+  startsAt: string,
+  endsAt: string
+): { assignment: ShiftAssignmentRow; shiftDate: string } {
+  return {
+    shiftDate,
+    assignment: {
+      id: `${staffId}-${shiftDate}-${startsAt}`,
+      shift_id: 'shift',
+      staff_id: staffId,
+      starts_at: startsAt,
+      ends_at: endsAt,
+      role: 'full',
+      notes: null,
+      proposal_id: null,
+      is_draft: false,
+      created_at: '',
+      updated_at: '',
+    },
+  };
+}
+
+describe('date helpers', () => {
+  it('finds the Monday of a week', () => {
+    expect(weekStartOf('2026-07-08')).toBe('2026-07-06'); // Wednesday → Monday
+    expect(weekStartOf('2026-07-06')).toBe('2026-07-06'); // Monday → itself
+    expect(weekStartOf('2026-07-12')).toBe('2026-07-06'); // Sunday → same week
+  });
+
+  it('adds days across month ends', () => {
+    expect(addDays('2026-07-31', 1)).toBe('2026-08-01');
+    expect(addDays('2026-08-01', -1)).toBe('2026-07-31');
+  });
+});
+
+describe('assignmentHours', () => {
+  it('computes fractional hours', () => {
+    expect(assignmentHours('15:00:00', '20:30:00')).toBe(5.5);
+    expect(assignmentHours('15:00', '16:00')).toBe(1);
+  });
+});
+
+describe('rollupHours', () => {
+  it('reproduces the sheet’s week of Jul 8–12 totals and % founders', () => {
+    // The sheet's Shift Log for that week (founders: Wes, Julien).
+    const rows = [
+      assignment('wes', '2026-07-08', '15:00', '20:30'),
+      assignment('julien', '2026-07-08', '15:00', '16:00'),
+      assignment('julien', '2026-07-09', '15:00', '20:00'),
+      assignment('omar', '2026-07-09', '15:00', '16:00'),
+      assignment('wes', '2026-07-10', '14:00', '22:00'),
+      assignment('omar', '2026-07-10', '14:00', '22:00'),
+      assignment('julien', '2026-07-11', '09:00', '16:30'),
+      assignment('althea', '2026-07-11', '09:00', '10:00'),
+      assignment('wes', '2026-07-12', '12:00', '16:30'),
+    ];
+
+    const weeks = rollupHours(rows, new Set(['wes', 'julien']));
+    expect(weeks).toHaveLength(1);
+
+    const week = weeks[0];
+    expect(week.weekStart).toBe('2026-07-06');
+    expect(week.byStaff).toEqual({ wes: 18, julien: 13.5, omar: 9, althea: 1 });
+    expect(week.total).toBe(41.5);
+    expect(week.founderShare).toBeCloseTo(0.759, 3);
+    expect(week.days.map((d) => d.date)).toEqual([
+      '2026-07-08',
+      '2026-07-09',
+      '2026-07-10',
+      '2026-07-11',
+      '2026-07-12',
+    ]);
+  });
+
+  it('splits assignments into separate Monday-start weeks, sorted', () => {
+    const weeks = rollupHours(
+      [
+        assignment('a', '2026-07-19', '12:00', '14:00'),
+        assignment('a', '2026-07-20', '12:00', '14:00'),
+      ],
+      new Set()
+    );
+    // Jul 19 is a Sunday (week of Jul 13); Jul 20 the following Monday.
+    expect(weeks.map((w) => w.weekStart)).toEqual(['2026-07-13', '2026-07-20']);
+  });
+
+  it('sums multiple same-day assignments and reports null founder share for empty weeks', () => {
+    const weeks = rollupHours(
+      [
+        assignment('a', '2026-07-08', '09:00', '10:00'),
+        assignment('a', '2026-07-08', '15:00', '16:30'),
+      ],
+      new Set()
+    );
+    expect(weeks[0].byStaff.a).toBe(2.5);
+    expect(weeks[0].founderShare).toBe(0);
+    expect(rollupHours([], new Set())).toEqual([]);
+  });
+});

--- a/packages/schedule-core/test/windows.test.ts
+++ b/packages/schedule-core/test/windows.test.ts
@@ -1,0 +1,200 @@
+// Window derivation + sync planning drive what the Momence sync writes to the
+// shifts table, so the merge/pad/round rules and every divergence class
+// (moved, cancelled-with-assignments, cancelled-clean, locked) get pinned.
+
+import { describe, expect, it } from 'vitest';
+import {
+  type CoverageEvent,
+  DEFAULT_WINDOW_OPTIONS,
+  deriveCoverageWindows,
+  labelForWindow,
+  planShiftSync,
+  type SyncShiftInput,
+} from '../src/windows';
+import { timeToMinutes } from '../src/availability';
+import { utcToEastern } from '../src/tz';
+
+const min = timeToMinutes;
+
+function event(partial: Partial<CoverageEvent> & { startMin: number; endMin: number }): CoverageEvent {
+  return {
+    kind: 'session',
+    id: 1,
+    title: 'Social Sauna',
+    date: '2026-08-12',
+    ...partial,
+  };
+}
+
+describe('utcToEastern', () => {
+  it('converts summer (EDT, UTC-4) timestamps', () => {
+    expect(utcToEastern('2026-08-12T20:00:00Z')).toEqual({ date: '2026-08-12', minutes: min('16:00') });
+  });
+
+  it('converts winter (EST, UTC-5) timestamps', () => {
+    expect(utcToEastern('2026-01-15T20:00:00Z')).toEqual({ date: '2026-01-15', minutes: min('15:00') });
+  });
+
+  it('rolls the calendar date back across midnight UTC', () => {
+    // 01:30 UTC = 21:30 ET the previous day (summer)
+    expect(utcToEastern('2026-08-13T01:30:00Z')).toEqual({ date: '2026-08-12', minutes: min('21:30') });
+  });
+});
+
+describe('deriveCoverageWindows', () => {
+  it('pads a single session by lead/close and rounds to :30', () => {
+    // 16:00–17:15 session → 15:00 lead, 17:45 close → ceil to 18:00
+    const [w] = deriveCoverageWindows([event({ startMin: min('16:00'), endMin: min('17:15') })]);
+    expect(w.startMin).toBe(min('15:00'));
+    expect(w.endMin).toBe(min('18:00'));
+    expect(w.label).toBe('Evening');
+  });
+
+  it('merges back-to-back sessions into one window', () => {
+    // The sheet's classic evening: 16:00 and 18:30 sessions → one 15:00–20:30 shift
+    const windows = deriveCoverageWindows([
+      event({ id: 1, startMin: min('16:00'), endMin: min('17:00') }),
+      event({ id: 2, startMin: min('18:30'), endMin: min('20:00') }),
+    ]);
+    expect(windows).toHaveLength(1);
+    expect(windows[0].startMin).toBe(min('15:00'));
+    expect(windows[0].endMin).toBe(min('20:30'));
+    expect(windows[0].sessionRefs).toHaveLength(2);
+  });
+
+  it('splits sessions separated by more than the merge gap', () => {
+    // Morning 6:30 class vs evening 16:00 class → two windows (like 8/13's sheet rows)
+    const windows = deriveCoverageWindows([
+      event({ id: 1, startMin: min('06:30'), endMin: min('09:30') }),
+      event({ id: 2, startMin: min('16:00'), endMin: min('20:00') }),
+    ]);
+    expect(windows).toHaveLength(2);
+    expect(windows[0].label).toBe('Morning');
+    expect(windows[1].label).toBe('Evening');
+  });
+
+  it('never merges across dates and clamps padding at midnight', () => {
+    const windows = deriveCoverageWindows([
+      event({ id: 1, date: '2026-08-12', startMin: min('23:00'), endMin: min('23:45') }),
+      event({ id: 2, date: '2026-08-13', startMin: min('00:15'), endMin: min('01:00') }),
+    ]);
+    expect(windows).toHaveLength(2);
+    expect(windows[0].endMin).toBe(24 * 60);
+    expect(windows[1].startMin).toBe(0);
+  });
+
+  it('interleaves appointments with sessions in the same window', () => {
+    const windows = deriveCoverageWindows([
+      event({ id: 1, startMin: min('16:00'), endMin: min('17:00') }),
+      event({ kind: 'appointment', id: 9, title: 'Private event', startMin: min('17:30'), endMin: min('19:00') }),
+    ]);
+    expect(windows).toHaveLength(1);
+    expect(windows[0].sessionRefs).toEqual([
+      { type: 'session', id: 1 },
+      { type: 'appointment', id: 9 },
+    ]);
+  });
+});
+
+describe('labelForWindow', () => {
+  it('labels like the sheet', () => {
+    expect(labelForWindow(min('05:30'), min('10:30'))).toBe('Morning');
+    expect(labelForWindow(min('08:30'), min('16:30'))).toBe('Day');
+    expect(labelForWindow(min('11:30'), min('16:30'))).toBe('Afternoon');
+    expect(labelForWindow(min('14:30'), min('20:30'))).toBe('Evening');
+  });
+});
+
+describe('planShiftSync', () => {
+  const window = (over: Partial<ReturnType<typeof deriveCoverageWindows>[number]> = {}) => ({
+    date: '2026-08-12',
+    startMin: min('15:00'),
+    endMin: min('20:30'),
+    label: 'Evening',
+    staffNeeded: 2,
+    sessionRefs: [{ type: 'session' as const, id: 1 }],
+    titles: ['Social Sauna'],
+    ...over,
+  });
+
+  const shift = (over: Partial<SyncShiftInput> = {}): SyncShiftInput => ({
+    id: 'shift-1',
+    shift_date: '2026-08-12',
+    starts_at: '15:00:00',
+    ends_at: '20:30:00',
+    source: 'momence',
+    momence_session_ids: [{ type: 'session', id: 1 }],
+    sync_locked: false,
+    status: 'active',
+    sync_flag: null,
+    is_draft: false,
+    assignmentCount: 0,
+    ...over,
+  });
+
+  it('creates windows with no matching shift', () => {
+    const plan = planShiftSync([window()], []);
+    expect(plan.create).toHaveLength(1);
+  });
+
+  it('no-ops when times and refs match, clearing stale flags', () => {
+    const plan = planShiftSync([window()], [shift({ sync_flag: 'times_changed' })]);
+    expect(plan).toMatchObject({ create: [], update: [], cancel: [], flag: [] });
+    expect(plan.clearFlag).toEqual(['shift-1']);
+  });
+
+  it('updates an unlocked shift whose session times moved', () => {
+    const plan = planShiftSync([window({ startMin: min('14:30') })], [shift()]);
+    expect(plan.update).toEqual([
+      {
+        shiftId: 'shift-1',
+        startsAt: '14:30',
+        endsAt: '20:30',
+        sessionRefs: [{ type: 'session', id: 1 }],
+      },
+    ]);
+  });
+
+  it('flags instead of updating when the shift is sync_locked', () => {
+    const plan = planShiftSync([window({ startMin: min('14:30') })], [shift({ sync_locked: true })]);
+    expect(plan.update).toHaveLength(0);
+    expect(plan.flag).toEqual([{ shiftId: 'shift-1', flag: 'times_changed' }]);
+  });
+
+  it('auto-cancels an unassigned shift whose sessions disappeared', () => {
+    const plan = planShiftSync([], [shift()]);
+    expect(plan.cancel).toEqual([{ shiftId: 'shift-1', reason: 'Momence sessions removed' }]);
+  });
+
+  it('flags (never cancels) a staffed shift whose sessions disappeared', () => {
+    const plan = planShiftSync([], [shift({ assignmentCount: 2 })]);
+    expect(plan.cancel).toHaveLength(0);
+    expect(plan.flag).toEqual([{ shiftId: 'shift-1', flag: 'sessions_cancelled' }]);
+  });
+
+  it('delete-and-replace nets one flagged staffed shift plus one new window', () => {
+    // Evening session deleted, morning session added instead: the staffed
+    // evening shift gets flagged, the morning window is created fresh.
+    const morningReplacement = window({
+      sessionRefs: [{ type: 'session', id: 2 }],
+      startMin: min('08:00'),
+      endMin: min('12:00'),
+      label: 'Morning',
+    });
+    const plan = planShiftSync([morningReplacement], [shift({ assignmentCount: 1 })]);
+    expect(plan.create).toHaveLength(1);
+    expect(plan.flag).toEqual([{ shiftId: 'shift-1', flag: 'sessions_cancelled' }]);
+  });
+
+  it('ignores manual, draft, and already-cancelled shifts', () => {
+    const plan = planShiftSync(
+      [],
+      [
+        shift({ id: 'manual', source: 'manual' }),
+        shift({ id: 'draft', is_draft: true }),
+        shift({ id: 'gone', status: 'cancelled' }),
+      ]
+    );
+    expect(plan).toEqual({ create: [], update: [], cancel: [], flag: [], clearFlag: [] });
+  });
+});

--- a/packages/schedule-core/tsconfig.json
+++ b/packages/schedule-core/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "lib": ["es2020"],
+    "types": ["node"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ai-sdk/gateway@npm:4.0.26":
+  version: 4.0.26
+  resolution: "@ai-sdk/gateway@npm:4.0.26"
+  dependencies:
+    "@ai-sdk/provider": "npm:4.0.3"
+    "@ai-sdk/provider-utils": "npm:5.0.12"
+    "@vercel/oidc": "npm:3.2.0"
+  peerDependencies:
+    zod: ^3.25.76 || ^4.1.8
+  checksum: 10c0/395f012ad4f762d954ac67ce32accc27a7c7777272513307e5b7d4d0f07413337afe20740661e78df36ca80be013d1f3ffc4f62581644d7c735e15f44d255c3e
+  languageName: node
+  linkType: hard
+
+"@ai-sdk/provider-utils@npm:5.0.12":
+  version: 5.0.12
+  resolution: "@ai-sdk/provider-utils@npm:5.0.12"
+  dependencies:
+    "@ai-sdk/provider": "npm:4.0.3"
+    "@standard-schema/spec": "npm:^1.1.0"
+    "@workflow/serde": "npm:4.1.0"
+    eventsource-parser: "npm:^3.0.8"
+  peerDependencies:
+    zod: ^3.25.76 || ^4.1.8
+  checksum: 10c0/223b0ecd752511a806e98f8500618874210d7f5c3b0238a33ac9702b27a40e701ce78ede1c19fd11996a01ebd3225388e4acf6e327f2c821dd319fd3c866ffd4
+  languageName: node
+  linkType: hard
+
+"@ai-sdk/provider@npm:4.0.3":
+  version: 4.0.3
+  resolution: "@ai-sdk/provider@npm:4.0.3"
+  dependencies:
+    json-schema: "npm:^0.4.0"
+  checksum: 10c0/4af0a9592baffbde5b4bb04668a2dfe41750405f0f35f7df86ba0ef3ba46e505d3ad1352cc4cfbe9580ac82d60f11fbb2bf1b55761deb268d99a611d146f3d7f
+  languageName: node
+  linkType: hard
+
 "@astrojs/check@npm:0.9.9":
   version: 0.9.9
   resolution: "@astrojs/check@npm:0.9.9"
@@ -2380,6 +2416,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxc-project/types@npm:=0.143.0":
+  version: 0.143.0
+  resolution: "@oxc-project/types@npm:0.143.0"
+  checksum: 10c0/f450bdc6ebd69b09b5d77c1ca45369f9e1a2b69d21f9dfcdaaa2379e8d5228bfdd014e77bef9bc21ca5fd118fb9e2213d30d8eb70299f03b1aac5ee1ab2802ba
+  languageName: node
+  linkType: hard
+
 "@oxc-project/types@npm:^0.127.0":
   version: 0.127.0
   resolution: "@oxc-project/types@npm:0.127.0"
@@ -2634,6 +2677,16 @@ __metadata:
   resolution: "@pyre/monorepo@workspace:."
   dependencies:
     turbo: "npm:^2.5.8"
+  languageName: unknown
+  linkType: soft
+
+"@pyre/schedule-core@workspace:^, @pyre/schedule-core@workspace:packages/schedule-core":
+  version: 0.0.0-use.local
+  resolution: "@pyre/schedule-core@workspace:packages/schedule-core"
+  dependencies:
+    "@types/node": "npm:^22.20.1"
+    typescript: "npm:^5.9.3"
+    vitest: "npm:^4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -2958,9 +3011,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-android-arm64@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-android-arm64@npm:1.2.3"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-darwin-arm64@npm:1.2.2":
   version: 1.2.2
   resolution: "@rolldown/binding-darwin-arm64@npm:1.2.2"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-darwin-arm64@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-darwin-arm64@npm:1.2.3"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -2972,9 +3039,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-darwin-x64@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-darwin-x64@npm:1.2.3"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-freebsd-x64@npm:1.2.2":
   version: 1.2.2
   resolution: "@rolldown/binding-freebsd-x64@npm:1.2.2"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-freebsd-x64@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-freebsd-x64@npm:1.2.3"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -2986,9 +3067,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-linux-arm-gnueabihf@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.2.3"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-linux-arm64-gnu@npm:1.2.2":
   version: 1.2.2
   resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.2.2"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-gnu@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.2.3"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
@@ -3000,9 +3095,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-linux-arm64-musl@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.2.3"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-linux-ppc64-gnu@npm:1.2.2":
   version: 1.2.2
   resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.2.2"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-ppc64-gnu@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.2.3"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
@@ -3014,9 +3123,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-linux-s390x-gnu@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.2.3"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-linux-x64-gnu@npm:1.2.2":
   version: 1.2.2
   resolution: "@rolldown/binding-linux-x64-gnu@npm:1.2.2"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-x64-gnu@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.2.3"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
@@ -3028,9 +3151,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-linux-x64-musl@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-linux-x64-musl@npm:1.2.3"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-openharmony-arm64@npm:1.2.2":
   version: 1.2.2
   resolution: "@rolldown/binding-openharmony-arm64@npm:1.2.2"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-openharmony-arm64@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-openharmony-arm64@npm:1.2.3"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
@@ -3042,9 +3179,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-win32-arm64-msvc@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.2.3"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-win32-x64-msvc@npm:1.2.2":
   version: 1.2.2
   resolution: "@rolldown/binding-win32-x64-msvc@npm:1.2.2"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-win32-x64-msvc@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.2.3"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -4010,6 +4161,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:^22.20.1":
+  version: 22.20.1
+  resolution: "@types/node@npm:22.20.1"
+  dependencies:
+    undici-types: "npm:~6.21.0"
+  checksum: 10c0/f2ba54d3d1fb92e1c57c78d32c3a17655b1e87363b707136f55c422b4838d4054901ce5d27f75bb0e5ecb7ebfee3804e0987822d22b473473008091857a09353
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^24.0.0":
+  version: 24.13.3
+  resolution: "@types/node@npm:24.13.3"
+  dependencies:
+    undici-types: "npm:~7.18.0"
+  checksum: 10c0/a5bc08f49b9581dcdca90e02cd77197a3c799840807664942e5cd5161a553d4d2ae8064f7e3294410d748d7d098b5c1848be7fa50c06f29c4193ab16be4e59eb
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:^24.9.2":
   version: 24.12.4
   resolution: "@types/node@npm:24.12.4"
@@ -4173,6 +4342,13 @@ __metadata:
   bin:
     nft: out/cli.js
   checksum: 10c0/e44f2bb41908f11ece98aa5c4f33b7ff6575a5102ab2db2675f4ee74bcc62439dce4d363a393f80a677898f63f7cac5741685653ee97a924e61e75c9d5b504d6
+  languageName: node
+  linkType: hard
+
+"@vercel/oidc@npm:3.2.0":
+  version: 3.2.0
+  resolution: "@vercel/oidc@npm:3.2.0"
+  checksum: 10c0/98318d3236f58c296616c8c2e1655b268c7bf58525bcd985adac7af6d900e05fc610f6f03ce2ff4bdcd3df7885a40c0ca44fdc761f122dcfe15a78c2756b0243
   languageName: node
   linkType: hard
 
@@ -4435,6 +4611,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@workflow/serde@npm:4.1.0":
+  version: 4.1.0
+  resolution: "@workflow/serde@npm:4.1.0"
+  checksum: 10c0/8ec68cd9448b486bc8244d1f2b33d64d4af4b0fc18d33417699ce29345b21e4359d880c5ea5d66872def4576c0cddcfa2a63282d1f4d661c455663c075595e81
+  languageName: node
+  linkType: hard
+
 "abbrev@npm:^3.0.0":
   version: 3.0.1
   resolution: "abbrev@npm:3.0.1"
@@ -4499,6 +4682,19 @@ __metadata:
   version: 7.1.4
   resolution: "agent-base@npm:7.1.4"
   checksum: 10c0/c2c9ab7599692d594b6a161559ada307b7a624fa4c7b03e3afdb5a5e31cd0e53269115b620fcab024c5ac6a6f37fa5eb2e004f076ad30f5f7e6b8b671f7b35fe
+  languageName: node
+  linkType: hard
+
+"ai@npm:7.0.34":
+  version: 7.0.34
+  resolution: "ai@npm:7.0.34"
+  dependencies:
+    "@ai-sdk/gateway": "npm:4.0.26"
+    "@ai-sdk/provider": "npm:4.0.3"
+    "@ai-sdk/provider-utils": "npm:5.0.12"
+  peerDependencies:
+    zod: ^3.25.76 || ^4.1.8
+  checksum: 10c0/fb90bd3f6646d6cfc8689bbe9fb48191a4ea43bfd85227215dede38c49c0629eb214a76f913c9c089f1a3627f492e4a3b86eaf058b66b40507353499ffac98b1
   languageName: node
   linkType: hard
 
@@ -5185,7 +5381,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"consola@npm:^3.2.3":
+"consola@npm:^3.2.3, consola@npm:^3.4.2":
   version: 3.4.2
   resolution: "consola@npm:3.4.2"
   checksum: 10c0/7cebe57ecf646ba74b300bcce23bff43034ed6fbec9f7e39c27cee1dc00df8a21cd336b466ad32e304ea70fba04ec9e890c200270de9a526ce021ba8a7e4c11a
@@ -5236,6 +5432,18 @@ __metadata:
   dependencies:
     uncrypto: "npm:^0.1.3"
   checksum: 10c0/9e873546f0806606c4f775219f6811768fc3b3b0765ca8230722e849058ad098318af006e1faa39a8008c03009c37c519f6bccad41b0d78586237585c75fb38b
+  languageName: node
+  linkType: hard
+
+"crossws@npm:^0.4.6, crossws@npm:^0.4.8":
+  version: 0.4.10
+  resolution: "crossws@npm:0.4.10"
+  peerDependencies:
+    srvx: ">=0.11.5"
+  peerDependenciesMeta:
+    srvx:
+      optional: true
+  checksum: 10c0/dae29657672f4d9fc964150ae4ce7c31fd065885812c86c00ee29a2843813c6f5aaf9556d91dc75fecf9c606771b709f2d1b9ed26c7fa44d374b2c23fba84114
   languageName: node
   linkType: hard
 
@@ -5306,6 +5514,33 @@ __metadata:
   version: 4.0.1
   resolution: "data-uri-to-buffer@npm:4.0.1"
   checksum: 10c0/20a6b93107597530d71d4cb285acee17f66bcdfc03fd81040921a81252f19db27588d87fc8fc69e1950c55cfb0bf8ae40d0e5e21d907230813eb5d5a7f9eb45b
+  languageName: node
+  linkType: hard
+
+"db0@npm:^0.3.4":
+  version: 0.3.4
+  resolution: "db0@npm:0.3.4"
+  peerDependencies:
+    "@electric-sql/pglite": "*"
+    "@libsql/client": "*"
+    better-sqlite3: "*"
+    drizzle-orm: "*"
+    mysql2: "*"
+    sqlite3: "*"
+  peerDependenciesMeta:
+    "@electric-sql/pglite":
+      optional: true
+    "@libsql/client":
+      optional: true
+    better-sqlite3:
+      optional: true
+    drizzle-orm:
+      optional: true
+    mysql2:
+      optional: true
+    sqlite3:
+      optional: true
+  checksum: 10c0/cd069a39783b8a160180ba4ae1a9832cd063e4f5d269442c7e7dd3e5713965e01f4d11272d5c79699e9723f4c79ba67159e52ec34b4a61e7349609865f20a368
   languageName: node
   linkType: hard
 
@@ -5617,6 +5852,34 @@ __metadata:
   version: 3.0.0
   resolution: "env-paths@npm:3.0.0"
   checksum: 10c0/76dec878cee47f841103bacd7fae03283af16f0702dad65102ef0a556f310b98a377885e0f32943831eb08b5ab37842a323d02529f3dfd5d0a40ca71b01b435f
+  languageName: node
+  linkType: hard
+
+"env-runner@npm:^0.1.12":
+  version: 0.1.16
+  resolution: "env-runner@npm:0.1.16"
+  dependencies:
+    crossws: "npm:^0.4.8"
+    exsolve: "npm:^1.1.0"
+    httpxy: "npm:^0.5.4"
+    srvx: "npm:^0.11.19"
+  peerDependencies:
+    "@netlify/runtime": ^4.1.23
+    "@vercel/queue": ">=0.2.0"
+    miniflare: ^4.20260515.0
+    wrangler: ^4.0.0
+  peerDependenciesMeta:
+    "@netlify/runtime":
+      optional: true
+    "@vercel/queue":
+      optional: true
+    miniflare:
+      optional: true
+    wrangler:
+      optional: true
+  bin:
+    env-runner: dist/cli.mjs
+  checksum: 10c0/67561779929f3cb0d6a7a0594f43248ef2b33433b814fba26da4ea2f393417e09d57a025275af83cf0a07962f53f885edfddde1244338c20f3db476cd63c2e0d
   languageName: node
   linkType: hard
 
@@ -6031,10 +6294,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eve@npm:0.27.0":
+  version: 0.27.0
+  resolution: "eve@npm:0.27.0"
+  dependencies:
+    nitro: "npm:3.0.260610-beta"
+  peerDependencies:
+    "@opentelemetry/api": ^1.0.0
+    ai: ^7.0.26
+    braintrust: ^3.0.0
+    just-bash: ^3.0.0
+    microsandbox: ^0.5.0
+  peerDependenciesMeta:
+    "@opentelemetry/api":
+      optional: true
+    braintrust:
+      optional: true
+    just-bash:
+      optional: true
+    microsandbox:
+      optional: true
+  bin:
+    eve: ./bin/eve.js
+  checksum: 10c0/ee1d84533bfad858a950636c7ca7dba342e1ed8e653592987d2689d6ed9cf8a9658669bdb0a4922ea6110a6283e9010916f9848679b003e57b550a66953f87fa
+  languageName: node
+  linkType: hard
+
 "eventemitter3@npm:^5.0.4":
   version: 5.0.4
   resolution: "eventemitter3@npm:5.0.4"
   checksum: 10c0/575b8cac8d709e1473da46f8f15ef311b57ff7609445a7c71af5cd42598583eee6f098fa7a593e30f27e94b8865642baa0689e8fa97c016f742abdb3b1bf6d9a
+  languageName: node
+  linkType: hard
+
+"eventsource-parser@npm:^3.0.8":
+  version: 3.1.0
+  resolution: "eventsource-parser@npm:3.1.0"
+  checksum: 10c0/5ab4c6c9a2a042be0b387b6d03810eb580bac4ce90e299ede56458125a97ffe3af8145b2740089fc898a96cfa5aae792ee79f2a06257fba2776b0e7bce037071
   languageName: node
   linkType: hard
 
@@ -6049,6 +6345,13 @@ __metadata:
   version: 3.1.3
   resolution: "exponential-backoff@npm:3.1.3"
   checksum: 10c0/77e3ae682b7b1f4972f563c6dbcd2b0d54ac679e62d5d32f3e5085feba20483cf28bd505543f520e287a56d4d55a28d7874299941faf637e779a1aa5994d1267
+  languageName: node
+  linkType: hard
+
+"exsolve@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "exsolve@npm:1.1.1"
+  checksum: 10c0/0b157a7600408bd356ff78cff5ad9c8c0dd7ca5e7f246216c3c9b66196e76277d3130021122b9c5078a3462751fd7aa988fe3dc1e3b80c79cb873c1623f628e1
   languageName: node
   linkType: hard
 
@@ -6311,6 +6614,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"h3@npm:2.0.1-rc.22":
+  version: 2.0.1-rc.22
+  resolution: "h3@npm:2.0.1-rc.22"
+  dependencies:
+    rou3: "npm:^0.8.1"
+    srvx: "npm:^0.11.15"
+  peerDependencies:
+    crossws: ^0.4.1
+  peerDependenciesMeta:
+    crossws:
+      optional: true
+  bin:
+    h3: bin/h3.mjs
+  checksum: 10c0/34c5896a279ff20c5bb556bf8bf8a5baccb3ef4bdd90fd47409dc53a8f7d0ca9775c294b7b5604f7e3c52e5bc29e2ed87938c0336ab64a1076bb0cefdfe066d0
+  languageName: node
+  linkType: hard
+
 "h3@npm:^1.15.10":
   version: 1.15.11
   resolution: "h3@npm:1.15.11"
@@ -6521,6 +6841,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hookable@npm:^6.1.1":
+  version: 6.1.1
+  resolution: "hookable@npm:6.1.1"
+  checksum: 10c0/bb46cd9ffc0a997af21febd97835da4e59a6989adec73dc3c215fcc44c7ac01de4781f251c3d420bf45862d2592a695f5f0de095b6f5df52db8afb5166938212
+  languageName: node
+  linkType: hard
+
 "html-escaper@npm:3.0.3":
   version: 3.0.3
   resolution: "html-escaper@npm:3.0.3"
@@ -6574,6 +6901,13 @@ __metadata:
     agent-base: "npm:^7.1.2"
     debug: "npm:4"
   checksum: 10c0/f729219bc735edb621fa30e6e84e60ee5d00802b8247aac0d7b79b0bd6d4b3294737a337b93b86a0bd9e68099d031858a39260c976dc14cdbba238ba1f8779ac
+  languageName: node
+  linkType: hard
+
+"httpxy@npm:^0.5.4":
+  version: 0.5.5
+  resolution: "httpxy@npm:0.5.5"
+  checksum: 10c0/7be52cbfbd4157b4ac3aa22124d06081e8ffc50a185622e43c0ce8229bbcd7411d016f4a364fecb694325ed312823efbf51c70fa8049563a8b6b617642914cd3
   languageName: node
   linkType: hard
 
@@ -6795,6 +7129,13 @@ __metadata:
   version: 8.0.2
   resolution: "json-schema-typed@npm:8.0.2"
   checksum: 10c0/89f5e2fb1495483b705c027203c07277ee6bf2665165ad25a9cb55de5af7f72570326d13d32565180781e4083ad5c9688102f222baed7b353c2f39c1e02b0428
+  languageName: node
+  linkType: hard
+
+"json-schema@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "json-schema@npm:0.4.0"
+  checksum: 10c0/d4a637ec1d83544857c1c163232f3da46912e971d5bf054ba44fdb88f07d8d359a462b4aec46f2745efbc57053365608d88bc1d7b1729f7b4fc3369765639ed3
   languageName: node
   linkType: hard
 
@@ -8059,6 +8400,63 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nf3@npm:^0.3.17":
+  version: 0.3.23
+  resolution: "nf3@npm:0.3.23"
+  checksum: 10c0/ebe3d7be3fee4c1f389d3826a92b95a4325af170b43b0326a76f63d3ee7f4c4128793549684867f1a2317d9c5cf9b24b4b232a2a7f69f1a03249ec7074416c77
+  languageName: node
+  linkType: hard
+
+"nitro@npm:3.0.260610-beta":
+  version: 3.0.260610-beta
+  resolution: "nitro@npm:3.0.260610-beta"
+  dependencies:
+    consola: "npm:^3.4.2"
+    crossws: "npm:^0.4.6"
+    db0: "npm:^0.3.4"
+    env-runner: "npm:^0.1.12"
+    h3: "npm:2.0.1-rc.22"
+    hookable: "npm:^6.1.1"
+    nf3: "npm:^0.3.17"
+    ocache: "npm:^0.1.5"
+    ofetch: "npm:2.0.0-alpha.3"
+    ohash: "npm:^2.0.11"
+    rolldown: "npm:^1.1.0"
+    srvx: "npm:^0.11.16"
+    unenv: "npm:2.0.0-rc.24"
+    unstorage: "npm:2.0.0-alpha.7"
+  peerDependencies:
+    "@vercel/queue": ^0.3.0
+    dotenv: "*"
+    giget: "*"
+    jiti: ^2.7.0
+    rollup: ^4.61.1
+    vite: ^7 || ^8
+    xml2js: ^0.6.2
+    zephyr-agent: ^0.2.0
+  peerDependenciesMeta:
+    "@vercel/queue":
+      optional: true
+    dotenv:
+      optional: true
+    giget:
+      optional: true
+    jiti:
+      optional: true
+    rollup:
+      optional: true
+    vite:
+      optional: true
+    xml2js:
+      optional: true
+    zephyr-agent:
+      optional: true
+  bin:
+    nitro: dist/cli/index.mjs
+  checksum: 10c0/9385785ef6f9940eab6d5517958f390eb925c5fd1a8025ebaa04db90c773bcf55803af4816a9de1c572065a7f37bfce779a62c48eac4d394b35fde1434391d14
+  languageName: node
+  linkType: hard
+
 "nlcst-to-string@npm:^4.0.0":
   version: 4.0.0
   resolution: "nlcst-to-string@npm:4.0.0"
@@ -8221,6 +8619,22 @@ __metadata:
   version: 2.1.1
   resolution: "obug@npm:2.1.1"
   checksum: 10c0/59dccd7de72a047e08f8649e94c1015ec72f94eefb6ddb57fb4812c4b425a813bc7e7cd30c9aca20db3c59abc3c85cc7a62bb656a968741d770f4e8e02bc2e78
+  languageName: node
+  linkType: hard
+
+"ocache@npm:^0.1.5":
+  version: 0.1.5
+  resolution: "ocache@npm:0.1.5"
+  dependencies:
+    ohash: "npm:^2.0.11"
+  checksum: 10c0/a5919120452397361f25716d56c80b133c409f36abb2ed1746d70dfdb947eb8163d46e771d5eb8e04586f5b9982c03798d88f1a0e5357c55cfa96d428fafc757
+  languageName: node
+  linkType: hard
+
+"ofetch@npm:2.0.0-alpha.3":
+  version: 2.0.0-alpha.3
+  resolution: "ofetch@npm:2.0.0-alpha.3"
+  checksum: 10c0/d2b2529980d49c33a647c54cc37fde7a55601ed81c1ec53863c323d292704c84811a902df9840aeb09eb917eadc82996c15d25013002dde84dcdd6f98bb21d0d
   languageName: node
   linkType: hard
 
@@ -8770,6 +9184,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pyre-agents@workspace:apps/agents":
+  version: 0.0.0-use.local
+  resolution: "pyre-agents@workspace:apps/agents"
+  dependencies:
+    "@pyre/schedule-core": "workspace:^"
+    "@supabase/supabase-js": "npm:^2.110.5"
+    "@types/node": "npm:^24.0.0"
+    ai: "npm:7.0.34"
+    eve: "npm:0.27.0"
+    typescript: "npm:^5.9.3"
+    zod: "npm:^4.4.3"
+  languageName: unknown
+  linkType: soft
+
 "qr-code-styling@npm:^1.9.2":
   version: 1.9.2
   resolution: "qr-code-styling@npm:1.9.2"
@@ -9277,6 +9705,61 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rolldown@npm:^1.1.0":
+  version: 1.2.3
+  resolution: "rolldown@npm:1.2.3"
+  dependencies:
+    "@oxc-project/types": "npm:=0.143.0"
+    "@rolldown/binding-android-arm64": "npm:1.2.3"
+    "@rolldown/binding-darwin-arm64": "npm:1.2.3"
+    "@rolldown/binding-darwin-x64": "npm:1.2.3"
+    "@rolldown/binding-freebsd-x64": "npm:1.2.3"
+    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.2.3"
+    "@rolldown/binding-linux-arm64-gnu": "npm:1.2.3"
+    "@rolldown/binding-linux-arm64-musl": "npm:1.2.3"
+    "@rolldown/binding-linux-ppc64-gnu": "npm:1.2.3"
+    "@rolldown/binding-linux-s390x-gnu": "npm:1.2.3"
+    "@rolldown/binding-linux-x64-gnu": "npm:1.2.3"
+    "@rolldown/binding-linux-x64-musl": "npm:1.2.3"
+    "@rolldown/binding-openharmony-arm64": "npm:1.2.3"
+    "@rolldown/binding-win32-arm64-msvc": "npm:1.2.3"
+    "@rolldown/binding-win32-x64-msvc": "npm:1.2.3"
+    "@rolldown/pluginutils": "npm:^1.0.0"
+  dependenciesMeta:
+    "@rolldown/binding-android-arm64":
+      optional: true
+    "@rolldown/binding-darwin-arm64":
+      optional: true
+    "@rolldown/binding-darwin-x64":
+      optional: true
+    "@rolldown/binding-freebsd-x64":
+      optional: true
+    "@rolldown/binding-linux-arm-gnueabihf":
+      optional: true
+    "@rolldown/binding-linux-arm64-gnu":
+      optional: true
+    "@rolldown/binding-linux-arm64-musl":
+      optional: true
+    "@rolldown/binding-linux-ppc64-gnu":
+      optional: true
+    "@rolldown/binding-linux-s390x-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-musl":
+      optional: true
+    "@rolldown/binding-openharmony-arm64":
+      optional: true
+    "@rolldown/binding-win32-arm64-msvc":
+      optional: true
+    "@rolldown/binding-win32-x64-msvc":
+      optional: true
+  bin:
+    rolldown: ./bin/cli.mjs
+  checksum: 10c0/4dbeabc826e59877c7520b2ae1f48d0111e1d21865f5931ff3d184d33f02683e943e65eb24932128fc03701bbcde1b341f313b3fa7f8007368bd1b5e993265f0
+  languageName: node
+  linkType: hard
+
 "rolldown@npm:~1.2.0":
   version: 1.2.2
   resolution: "rolldown@npm:1.2.2"
@@ -9419,6 +9902,13 @@ __metadata:
   bin:
     rollup: dist/bin/rollup
   checksum: 10c0/72c9c768f3fabeaeff228b6364e6600c169d6c231a4324c47c34880fd8961aebacd974cf905ecc2db75e56c6491bdd676409a06aecf589791bf419cd41d06e76
+  languageName: node
+  linkType: hard
+
+"rou3@npm:^0.8.1":
+  version: 0.8.1
+  resolution: "rou3@npm:0.8.1"
+  checksum: 10c0/c8728cf3c41833db0e20cbadba07b3c678b8b9fb12db1d8803f275a7a6cce02d0be9bee79367575883f65659c9c0ed1001e6527146ed27772e439e5d6c68d264
   languageName: node
   linkType: hard
 
@@ -9766,6 +10256,15 @@ __metadata:
   version: 2.0.2
   resolution: "space-separated-tokens@npm:2.0.2"
   checksum: 10c0/6173e1d903dca41dcab6a2deed8b4caf61bd13b6d7af8374713500570aa929ff9414ae09a0519f4f8772df993300305a395d4871f35bc4ca72b6db57e1f30af8
+  languageName: node
+  linkType: hard
+
+"srvx@npm:^0.11.15, srvx@npm:^0.11.16, srvx@npm:^0.11.19":
+  version: 0.11.22
+  resolution: "srvx@npm:0.11.22"
+  bin:
+    srvx: bin/srvx.mjs
+  checksum: 10c0/aae81d7aa2d43e23fd483088533ad471ee2cd28f2065b84119635fd9feabdd4bab94fc06b8d198c205e3613b552624ccd2015c887ba9ca415d9c51dde7e6ec79
   languageName: node
   linkType: hard
 
@@ -10321,6 +10820,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici-types@npm:~7.18.0":
+  version: 7.18.2
+  resolution: "undici-types@npm:7.18.2"
+  checksum: 10c0/85a79189113a238959d7a647368e4f7c5559c3a404ebdb8fc4488145ce9426fcd82252a844a302798dfc0e37e6fb178ff481ed03bc4caf634c5757d9ef43521d
+  languageName: node
+  linkType: hard
+
 "undici-types@npm:~7.21.0":
   version: 7.21.0
   resolution: "undici-types@npm:7.21.0"
@@ -10332,6 +10838,15 @@ __metadata:
   version: 6.25.0
   resolution: "undici@npm:6.25.0"
   checksum: 10c0/2597cc6689bdb02c210c557b1f85febbfda65becae6e6fc1061508e2f33734d25207f81cd8af56ada9956329eb3a7bd7431e87dcfeceba20ee87059b57dcf985
+  languageName: node
+  linkType: hard
+
+"unenv@npm:2.0.0-rc.24":
+  version: 2.0.0-rc.24
+  resolution: "unenv@npm:2.0.0-rc.24"
+  dependencies:
+    pathe: "npm:^2.0.3"
+  checksum: 10c0/e8556b4287fcf647f23db790eea2782cc79f182370718680e3aba4753d5fb7177abf5d6df489c8f74f7e3ad6cd554b8623cc01caf3e6f2d5548e69178adb1691
   languageName: node
   linkType: hard
 
@@ -10466,6 +10981,84 @@ __metadata:
     picomatch: "npm:^4.0.3"
     webpack-virtual-modules: "npm:^0.6.2"
   checksum: 10c0/273c1eab0eca4470c7317428689295c31dbe8ab0b306504de9f03cd20c156debb4131bef24b27ac615862958c5dd950a3951d26c0723ea774652ab3624149cff
+  languageName: node
+  linkType: hard
+
+"unstorage@npm:2.0.0-alpha.7":
+  version: 2.0.0-alpha.7
+  resolution: "unstorage@npm:2.0.0-alpha.7"
+  peerDependencies:
+    "@azure/app-configuration": ^1.11.0
+    "@azure/cosmos": ^4.9.1
+    "@azure/data-tables": ^13.3.2
+    "@azure/identity": ^4.13.0
+    "@azure/keyvault-secrets": ^4.10.0
+    "@azure/storage-blob": ^12.31.0
+    "@capacitor/preferences": ^6 || ^7 || ^8
+    "@deno/kv": ">=0.13.0"
+    "@netlify/blobs": ^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0
+    "@planetscale/database": ^1.19.0
+    "@upstash/redis": ^1.36.2
+    "@vercel/blob": ">=0.27.3"
+    "@vercel/functions": ^2.2.12 || ^3.0.0
+    "@vercel/kv": ^1.0.1
+    aws4fetch: ^1.0.20
+    chokidar: ^4 || ^5
+    db0: ">=0.3.4"
+    idb-keyval: ^6.2.2
+    ioredis: ^5.9.3
+    lru-cache: ^11.2.6
+    mongodb: ^6 || ^7
+    ofetch: "*"
+    uploadthing: ^7.7.4
+  peerDependenciesMeta:
+    "@azure/app-configuration":
+      optional: true
+    "@azure/cosmos":
+      optional: true
+    "@azure/data-tables":
+      optional: true
+    "@azure/identity":
+      optional: true
+    "@azure/keyvault-secrets":
+      optional: true
+    "@azure/storage-blob":
+      optional: true
+    "@capacitor/preferences":
+      optional: true
+    "@deno/kv":
+      optional: true
+    "@netlify/blobs":
+      optional: true
+    "@planetscale/database":
+      optional: true
+    "@upstash/redis":
+      optional: true
+    "@vercel/blob":
+      optional: true
+    "@vercel/functions":
+      optional: true
+    "@vercel/kv":
+      optional: true
+    aws4fetch:
+      optional: true
+    chokidar:
+      optional: true
+    db0:
+      optional: true
+    idb-keyval:
+      optional: true
+    ioredis:
+      optional: true
+    lru-cache:
+      optional: true
+    mongodb:
+      optional: true
+    ofetch:
+      optional: true
+    uploadthing:
+      optional: true
+  checksum: 10c0/e0cd9896b27f3c9bc128333ef551a46d401843a4d93ad02dcffd9589d54c2c2b73e2f51440f02fda51c7941d31868ca0a69fa2e7e1f0f9b5489983814c8e9be6
   languageName: node
   linkType: hard
 
@@ -11377,7 +11970,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^4.3.6":
+"zod@npm:^4.3.6, zod@npm:^4.4.3":
   version: 4.4.3
   resolution: "zod@npm:4.4.3"
   checksum: 10c0/7ea31b558e88f9faf44f31dd185e2e1cbf51fed3081787fb96cc2534749b50c0acfc6da7f0922a7353ed092dd358c7d50c28ea96c94d04af64191bd33152eca3


### PR DESCRIPTION
Standalone slice of the AI scheduling work so the new **pyre-agents** Vercel project can deploy from master without waiting on the staging branch.

## What's in here

- **`apps/agents`** — Vercel Eve app (Node 24) hosting the staff-scheduling drafter:
  - `agent/tools/get_week_context` — reads roster/shifts/time-off/hours history straight from Supabase (dedicated `SUPABASE_AGENTS_SECRET_KEY`) and pre-computes the availability matrix
  - `agent/tools/save_proposal` — submits the draft through the integrations app's `POST /api/agent/proposals` (Bearer `AGENT_API_SECRET`); never writes tables directly
  - `agent/channels/eve.ts` — bearer-secret auth (`EVE_CHANNEL_SECRET`) for the session API, plus Vercel OIDC / local dev
  - `agent/schedules/weekly_draft.md` — Wed 14:00 UTC auto-draft (becomes a Vercel Cron Job on deploy)
  - offline evals (`AGENT_FORCE_DRY_RUN=1`)
- **`packages/schedule-core`** — pure scheduling logic shared with the integrations app (availability engine, hours rollup, Momence coverage-window derivation + sync planning), 37 vitest tests
- `.gitignore` entries for Eve build artifacts

## What's *not* in here (arrives via staging)

The integrations-side counterparts: the `schedule_proposals` migration, the `/api/agent/proposals` endpoint, the Momence sync job, and the admin-board review UI. Deploying this app first is safe — its tools just error until those land and the env vars below are set.

## Deploy checklist (also in `apps/agents/README.md`)

1. New Vercel project **pyre-agents**: Root Directory `apps/agents`, Node 24, AI Gateway enabled
2. Env: `SUPABASE_URL`, `SUPABASE_AGENTS_SECRET_KEY` (mint a dedicated key), `INTEGRATIONS_BASE_URL`, `AGENT_API_SECRET`, `EVE_CHANNEL_SECRET`
3. Verify `GET /eve/v1/health`

## Notes

- `typescript` is pinned to `^5.9.3` in the two new workspaces on this branch — master's Yarn 4.13 can't patch TS 7 yet; staging (Yarn 4.18) can restore the bump when it merges.
- Verified on this branch: `yarn install` clean, schedule-core 37/37 tests, `tsc --noEmit` clean, `eve build` compiles with 0 diagnostics.