### PR TITLE
Highlight chemical additions in the water log

### DIFF
--- a/apps/integrations/src/components/admin/WaterLog.tsx
+++ b/apps/integrations/src/components/admin/WaterLog.tsx
@@ -821,7 +821,10 @@ export function WaterLog({ userEmail }: { userEmail: string }) {
           Trends
         </summary>
         <div className="px-4 pb-4">
-          <WaterTrends records={chartRecords} visibleTubs={filter === 'all' ? [...TUBS] : [filter]} />
+          <WaterTrends
+            records={chartRecords}
+            visibleTubs={filter === 'all' ? [...TUBS] : [filter]}
+          />
         </div>
       </details>
 
@@ -851,22 +854,30 @@ export function WaterLog({ userEmail }: { userEmail: string }) {
 
           <ReadingChips record={record} />
 
+          {/* Anything put into the water is the entry's most consequential
+           * fact, so it gets its own gold-tinted block — scannable down a
+           * column of cards without reading any of them. */}
           {record.doses.length > 0 && (
-            <div className="mt-2 space-y-0.5">
-              {record.doses.map((dose) => (
-                <div
-                  key={`${record.id}-${dose.chemical}`}
-                  className="font-mono text-sm text-white/70"
-                >
-                  ＋ {dose.chemical} {dose.grams} g
-                  {dose.recommended_grams != null && dose.recommended_grams !== dose.grams && (
-                    <span className="text-[var(--pyre-gold)]">
-                      {' '}
-                      (chart: {dose.recommended_grams} g)
-                    </span>
-                  )}
-                </div>
-              ))}
+            <div className="mt-2 rounded border border-[var(--pyre-gold)]/40 bg-[var(--pyre-gold)]/10 px-2.5 py-2">
+              <div className="mb-1 font-mono-bold text-xs uppercase tracking-wide text-[var(--pyre-gold)]/70">
+                Added to water
+              </div>
+              <div className="space-y-0.5">
+                {record.doses.map((dose) => (
+                  <div
+                    key={`${record.id}-${dose.chemical}`}
+                    className="font-mono-bold text-sm text-[var(--pyre-gold)]"
+                  >
+                    ＋ {dose.chemical} {dose.grams} g
+                    {dose.recommended_grams != null && dose.recommended_grams !== dose.grams && (
+                      <span className="font-mono text-white/50">
+                        {' '}
+                        (chart: {dose.recommended_grams} g)
+                      </span>
+                    )}
+                  </div>
+                ))}
+              </div>
             </div>
           )}
 

--- a/apps/integrations/src/components/admin/WaterTrends.tsx
+++ b/apps/integrations/src/components/admin/WaterTrends.tsx
@@ -318,9 +318,10 @@ export function WaterTrends({
               <span className="text-white/40">{p.label}</span>
             </div>
           ))}
+          {/* Gold matches the log's "added to water" block. */}
           {hovered.doses.length > 0 && (
-            <div className="mt-1 font-mono text-xs text-white/40">
-              {hovered.doses.map((d) => `${d.chemical} ${d.grams} g`).join(', ')}
+            <div className="mt-1 font-mono-bold text-xs text-[var(--pyre-gold)]">
+              ＋ {hovered.doses.map((d) => `${d.chemical} ${d.grams} g`).join(', ')}
             </div>
           )}
         </div>


### PR DESCRIPTION
Doses were rendered in the same muted gray (`text-white/70`) as everything else on a log card, so an entry where someone actually put chemicals in the tub looked identical at a glance to a readings-only entry.

## Changes

**`WaterLog.tsx` — log entries**
- Doses now render in their own gold-tinted block (`border-[var(--pyre-gold)]/40` + `bg-[var(--pyre-gold)]/10`) with an "Added to water" label, instead of loose gray lines.
- Dose text itself is `--pyre-gold` and bold-mono, so a dosed entry is identifiable scrolling a column of cards without reading any of them.
- The "(chart: N g)" deviation note moved from gold to `text-white/50` — inside a gold block it needs to read as the secondary detail it is.

**`WaterTrends.tsx` — hover tooltip**
- Doses in the tooltip get the same gold treatment and a `＋` prefix so the two surfaces agree on what "something was added" looks like.

Gold is already the palette's attention color here (out-of-target reading chips, live "Add N g" field notes), so a gold chip explaining a gold dose block reads consistently. Red stays reserved for criticals and sage for in-range.

## Verification

- `yarn biome check` — clean on both files (one pre-existing warning in `WebhookHealthPanel.tsx`, untouched).
- `yarn type-check` — 0 errors.
- `yarn test` — 42 passed.
- `yarn build` — succeeds; confirmed Tailwind emits the `bg-[var(--pyre-gold)]/10` and `text-[var(--pyre-gold)]/70` utilities (with `color-mix` + fallback).
- Rendered the log markup against the compiled `admin.css` in Chromium to check contrast on the dark background.

No behavior, data, or API changes — presentation only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5hFgFEYJkRPhDF7E8RcWp)_