### PR TITLE
Highlight the signed-in user's own shifts in gold on the staff schedule

### DIFF
--- a/apps/integrations/src/components/admin/ScheduleBoard.tsx
+++ b/apps/integrations/src/components/admin/ScheduleBoard.tsx
@@ -2,7 +2,8 @@
 // status (the sheet's row colors), inline shift create/edit, and an
 // assignment picker that shows each person's availability — computed locally
 // via lib/schedule/availability from the same time-off data the API returns —
-// plus their hours already scheduled that week.
+// plus their hours already scheduled that week. Days the viewer works are
+// picked out in gold, with their own name first in each shift's name list.
 
 import {
   ASSIGNMENT_ROLE_LABELS,
@@ -18,7 +19,7 @@ import {
   timeToMinutes,
   weekStartOf,
 } from '@pyre/schedule-core';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type {
   ScheduleProposalRow,
   ShiftAssignmentRow,
@@ -106,6 +107,21 @@ const toneChip: Record<CoverageTone, string> = {
   cancelled: 'bg-white/10 text-white/50',
 };
 
+/**
+ * The viewer's own assignment sorts to the front of a shift's name list so
+ * they find themselves without reading the whole roster. Sort is stable, so
+ * everyone else keeps their existing order.
+ */
+const selfFirst = <T extends { staff_id: string }>(
+  rows: readonly T[],
+  selfId: string | null
+): T[] =>
+  selfId
+    ? [...rows].sort((a, b) => Number(b.staff_id === selfId) - Number(a.staff_id === selfId))
+    : [...rows];
+
+const selfNameClass = 'font-semibold text-[var(--pyre-gold)]';
+
 const availabilityBadge = (availability: Availability): { label: string; className: string } => {
   switch (availability.status) {
     case 'free':
@@ -190,6 +206,7 @@ export function ScheduleBoard() {
   }, [load]);
 
   const canManage = data?.canManage ?? false;
+  const selfId = data?.selfStaffId ?? null;
 
   const days = useMemo(
     () => Array.from({ length: 7 }, (_, i) => addDays(weekStart, i)),
@@ -207,6 +224,17 @@ export function ScheduleBoard() {
   }, [data]);
 
   const staffById = useMemo(() => new Map((data?.staff ?? []).map((s) => [s.id, s])), [data]);
+
+  // Days the viewer is on the schedule — those get the gold treatment.
+  const selfDates = useMemo(() => {
+    const dates = new Set<string>();
+    if (!selfId) return dates;
+    for (const shift of data?.shifts ?? []) {
+      if (shift.status === 'cancelled') continue;
+      if (shift.assignments.some((a) => a.staff_id === selfId)) dates.add(shift.shift_date);
+    }
+    return dates;
+  }, [data, selfId]);
 
   // Hours already scheduled this week per staff id (all shifts on the board).
   const weekHours = useMemo(() => {
@@ -419,11 +447,28 @@ export function ScheduleBoard() {
       <div className="space-y-4">
         {days.map((date) => {
           const shifts = shiftsByDate.get(date) ?? [];
+          const selfWorks = selfDates.has(date);
           return (
-            <section key={date} className="rounded-lg border border-white/10 bg-white/[0.03] p-3">
-              <div className="mb-2 flex items-center justify-between">
-                <h2 className="font-mono text-sm font-bold uppercase tracking-wide text-white/70">
+            <section
+              key={date}
+              className={`rounded-lg border p-3 ${
+                selfWorks
+                  ? 'border-[var(--pyre-gold)]/60 bg-[var(--pyre-gold)]/[0.06]'
+                  : 'border-white/10 bg-white/[0.03]'
+              }`}
+            >
+              <div className="mb-2 flex items-center justify-between gap-2">
+                <h2
+                  className={`flex flex-wrap items-center gap-2 font-mono text-sm font-bold uppercase tracking-wide ${
+                    selfWorks ? 'text-[var(--pyre-gold)]' : 'text-white/70'
+                  }`}
+                >
                   {formatDay(date)}
+                  {selfWorks && (
+                    <span className="rounded bg-[var(--pyre-gold)]/20 px-2 py-0.5 text-[10px] tracking-wide text-[var(--pyre-gold)]">
+                      you're on
+                    </span>
+                  )}
                 </h2>
                 {canManage && (
                   <button type="button" className={buttonClass} onClick={() => openNewShift(date)}>
@@ -495,9 +540,14 @@ export function ScheduleBoard() {
                             </span>
                           )}
                           <span className="text-sm text-white/70">
-                            {shift.assignments
-                              .map((a) => staffById.get(a.staff_id)?.display_name ?? '?')
-                              .join(', ')}
+                            {selfFirst(shift.assignments, selfId).map((a, i) => (
+                              <Fragment key={a.id}>
+                                {i > 0 && ', '}
+                                <span className={a.staff_id === selfId ? selfNameClass : undefined}>
+                                  {staffById.get(a.staff_id)?.display_name ?? '?'}
+                                </span>
+                              </Fragment>
+                            ))}
                           </span>
                           {shift.notes && (
                             <span className="font-mono text-xs text-white/40">{shift.notes}</span>
@@ -548,6 +598,7 @@ export function ScheduleBoard() {
                           busy={busy}
                           run={run}
                           canManage={canManage}
+                          selfId={selfId}
                           onEdit={() => openEditShift(shift)}
                           editingAssignment={editingAssignment}
                           setEditingAssignment={setEditingAssignment}
@@ -705,6 +756,7 @@ function ShiftDetail({
   busy,
   run,
   canManage,
+  selfId,
   onEdit,
   editingAssignment,
   setEditingAssignment,
@@ -717,6 +769,7 @@ function ShiftDetail({
   busy: boolean;
   run: (action: () => Promise<{ error?: string }>) => Promise<void>;
   canManage: boolean;
+  selfId: string | null;
   onEdit: () => void;
   editingAssignment: string | null;
   setEditingAssignment: (id: string | null) => void;
@@ -731,8 +784,9 @@ function ShiftDetail({
     <div className="space-y-3 border-t border-white/10 px-3 py-3">
       {shift.assignments.length > 0 && (
         <ul className="space-y-1.5">
-          {shift.assignments.map((a) => {
+          {selfFirst(shift.assignments, selfId).map((a) => {
             const person = staffById.get(a.staff_id);
+            const isSelf = a.staff_id === selfId;
             const availability = availabilityFor(
               data.timeOff,
               a.staff_id,
@@ -742,9 +796,14 @@ function ShiftDetail({
             );
             const editing = editingAssignment === a.id;
             return (
-              <li key={a.id} className="rounded bg-white/5 px-2 py-1.5">
+              <li
+                key={a.id}
+                className={`rounded px-2 py-1.5 ${isSelf ? 'bg-[var(--pyre-gold)]/10' : 'bg-white/5'}`}
+              >
                 <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-                  <span className="font-medium">{person?.display_name ?? '?'}</span>
+                  <span className={isSelf ? selfNameClass : 'font-medium'}>
+                    {person?.display_name ?? '?'}
+                  </span>
                   <span className="font-mono text-xs text-white/60">
                     {formatTime(a.starts_at)}–{formatTime(a.ends_at)} ·{' '}
                     {assignmentHours(a.starts_at, a.ends_at)}h · {ASSIGNMENT_ROLE_LABELS[a.role]}

--- a/apps/integrations/src/components/admin/ScheduleBoard.tsx
+++ b/apps/integrations/src/components/admin/ScheduleBoard.tsx
@@ -403,7 +403,7 @@ export function ScheduleBoard() {
         >
           Next ›
         </button>
-        <span className="font-mono text-sm text-white/60">
+        <span className="font-mono text-xl font-bold text-white/80">
           {formatDay(weekStart)} – {formatDay(addDays(weekStart, 6))}
         </span>
         {canManage && (

--- a/apps/integrations/src/components/admin/ScheduleCalendar.tsx
+++ b/apps/integrations/src/components/admin/ScheduleCalendar.tsx
@@ -1,7 +1,8 @@
 // Month calendar: the whole month as a Monday-start grid, shifts as
 // coverage-colored blocks in each day cell (label, window, who's on) and time
 // off as per-person colored markers along the cell bottom — so the month's
-// shape and everyone's availability read at a glance. Read-only; editing
+// shape and everyone's availability read at a glance. Days the viewer works
+// are tinted gold, with their own name first in the block. Read-only; editing
 // happens on the Week board.
 
 import {
@@ -11,7 +12,7 @@ import {
   timeToMinutes,
   weekStartOf,
 } from '@pyre/schedule-core';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
 import type { ShiftAssignmentRow, ShiftRow, StaffRow, TimeOffRow } from '@/lib/db';
 
 interface BoardShift extends ShiftRow {
@@ -22,6 +23,7 @@ interface BoardData {
   staff: StaffRow[];
   shifts: BoardShift[];
   timeOff: TimeOffRow[];
+  selfStaffId?: string | null;
 }
 
 const buttonClass =
@@ -100,6 +102,15 @@ const coverageTone = (shift: BoardShift): CoverageTone => {
   return 'covered';
 };
 
+/** The viewer's own assignment reads first in a shift's name list. */
+const selfFirst = <T extends { staff_id: string }>(
+  rows: readonly T[],
+  selfId: string | null
+): T[] =>
+  selfId
+    ? [...rows].sort((a, b) => Number(b.staff_id === selfId) - Number(a.staff_id === selfId))
+    : [...rows];
+
 const toneBlock: Record<CoverageTone, string> = {
   empty: 'border-[var(--pyre-red)]/70 bg-[var(--pyre-red)]/15',
   under: 'border-[var(--pyre-gold)]/70 bg-[var(--pyre-gold)]/15',
@@ -163,6 +174,19 @@ export function ScheduleCalendar() {
     }
     return map;
   }, [data]);
+
+  const selfId = data?.selfStaffId ?? null;
+
+  // Days the viewer is on the schedule — those cells get the gold treatment.
+  const selfDates = useMemo(() => {
+    const dates = new Set<string>();
+    if (!selfId) return dates;
+    for (const shift of data?.shifts ?? []) {
+      if (shift.status === 'cancelled') continue;
+      if (shift.assignments.some((a) => a.staff_id === selfId)) dates.add(shift.shift_date);
+    }
+    return dates;
+  }, [data, selfId]);
 
   // Per-day time-off markers: every active person with any busy interval.
   const timeOffByDate = useMemo(() => {
@@ -254,16 +278,26 @@ export function ScheduleCalendar() {
                 const inMonth = date.slice(0, 7) === monthStart.slice(0, 7);
                 const shifts = shiftsByDate.get(date) ?? [];
                 const markers = timeOffByDate.get(date) ?? [];
+                const selfWorks = selfDates.has(date);
+                const cellTone = selfWorks
+                  ? 'bg-[var(--pyre-gold)]/[0.08] ring-1 ring-inset ring-[var(--pyre-gold)]/40'
+                  : inMonth
+                    ? ''
+                    : 'bg-white/[0.02]';
                 return (
                   <div
                     key={date}
-                    className={`min-h-[110px] border-b border-l border-white/10 p-1.5 last:border-r ${
-                      inMonth ? '' : 'bg-white/[0.02] opacity-40'
+                    className={`min-h-[110px] border-b border-l border-white/10 p-1.5 last:border-r ${cellTone} ${
+                      inMonth ? '' : 'opacity-40'
                     }`}
                   >
                     <div
                       className={`mb-1 text-right font-mono text-[11px] ${
-                        date === today ? 'font-bold text-[var(--pyre-red)]' : 'text-white/40'
+                        date === today
+                          ? 'font-bold text-[var(--pyre-red)]'
+                          : selfWorks
+                            ? 'font-bold text-[var(--pyre-gold)]'
+                            : 'text-white/40'
                       }`}
                     >
                       {Number(date.slice(8))}
@@ -271,7 +305,8 @@ export function ScheduleCalendar() {
 
                     <div className="space-y-1">
                       {shifts.map((shift) => {
-                        const names = shift.assignments
+                        const assigned = selfFirst(shift.assignments, selfId);
+                        const names = assigned
                           .map((a) => staffById.get(a.staff_id)?.display_name ?? '?')
                           .join(', ');
                         return (
@@ -288,7 +323,20 @@ export function ScheduleCalendar() {
                             </span>
                             <span className="block truncate font-mono text-[10px] text-white/70 leading-tight">
                               {shift.assignments.length}/{shift.staff_needed}
-                              {names ? ` · ${names}` : ''}
+                              {assigned.map((a, i) => (
+                                <Fragment key={a.id}>
+                                  {i === 0 ? ' · ' : ', '}
+                                  <span
+                                    className={
+                                      a.staff_id === selfId
+                                        ? 'font-bold text-[var(--pyre-gold)]'
+                                        : undefined
+                                    }
+                                  >
+                                    {staffById.get(a.staff_id)?.display_name ?? '?'}
+                                  </span>
+                                </Fragment>
+                              ))}
                             </span>
                           </a>
                         );
@@ -334,6 +382,12 @@ export function ScheduleCalendar() {
           <span className="mr-1 inline-block h-2.5 w-2.5 rounded-sm border border-[var(--pyre-sage)]/60 bg-[var(--pyre-sage)]/15 align-middle" />
           covered
         </span>
+        {selfId && (
+          <span className="text-[var(--pyre-gold)]">
+            <span className="mr-1 inline-block h-2.5 w-2.5 rounded-sm bg-[var(--pyre-gold)]/25 ring-1 ring-inset ring-[var(--pyre-gold)]/60 align-middle" />
+            days you work
+          </span>
+        )}
         <span className="text-white/40">· lettered chips = time off:</span>
         {(data?.staff ?? [])
           .filter((s) => s.active)

--- a/apps/integrations/src/components/admin/ScheduleCalendar.tsx
+++ b/apps/integrations/src/components/admin/ScheduleCalendar.tsx
@@ -249,7 +249,7 @@ export function ScheduleCalendar() {
         >
           Next ›
         </button>
-        <span className="font-mono text-sm font-bold text-white/70">{formatMonth(monthStart)}</span>
+        <span className="font-mono text-xl font-bold text-white/80">{formatMonth(monthStart)}</span>
         {loading && <span className="font-mono text-xs text-white/40">Loading…</span>}
       </div>
 


### PR DESCRIPTION
Makes it obvious at a glance which days you're scheduled on the staff schedule.

Both views already receive `selfStaffId` from `/api/admin/schedule-board` (matched on the signed-in user's email) — this wires it into the UI.

## Week board (`ScheduleBoard.tsx`)
- Day sections where you have an assignment get a gold border/tint, a gold day heading, and a "you're on" chip.
- In each shift's name list (collapsed row and expanded detail), your name sorts first and renders in gold; your row in the expanded list gets a gold tint. Sorting is stable, so everyone else keeps their existing order.

## Month calendar (`ScheduleCalendar.tsx`)
- Day cells where you're scheduled get a gold tint and inset gold ring, and the date number goes gold (today's red still wins).
- Your name sorts first and renders gold inside the shift blocks.
- Legend gains a "days you work" swatch (shown only when the viewer maps to a staff row).

Cancelled shifts don't count toward the gold days.

## Checks
- `yarn workspace @pyre/integrations type-check` — 0 errors
- `biome check` on both changed files — clean

Not verified in a running browser (no Supabase env in this session).

---
_Generated by [Claude Code](https://claude.ai/code/session_019tQebsSy6oehHXjnwrp6M4)_