### PR TITLE
Default the water log test method to the TF-Pro Salt kit

### DIFF
--- a/apps/integrations/src/components/admin/WaterLog.tsx
+++ b/apps/integrations/src/components/admin/WaterLog.tsx
@@ -8,6 +8,7 @@
 import { type ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import type { DoseRecord, WaterTestRow } from '@/lib/db';
 import {
+  DEFAULT_TEST_METHOD,
   type EntryType,
   SHOCK_DOSES,
   TARGETS,
@@ -252,7 +253,7 @@ export function WaterLog({ userEmail }: { userEmail: string }) {
     cc: '',
     salt: '',
   });
-  const [testMethod, setTestMethod] = useState<TestMethod>('strips');
+  const [testMethod, setTestMethod] = useState<TestMethod>(DEFAULT_TEST_METHOD);
   const [notes, setNotes] = useState('');
   const [phase, setPhase] = useState<'entering' | 'reviewing'>('entering');
   const [recommendations, setRecommendations] = useState<Recommendation[]>([]);

--- a/apps/integrations/src/lib/water/charts.ts
+++ b/apps/integrations/src/lib/water/charts.ts
@@ -23,6 +23,10 @@ export const TEST_METHOD_LABELS: Record<TestMethod, string> = {
   tf_pro_salt: 'TF-Pro Salt',
 };
 
+// The TF-Pro Salt kit (Taylor reagents) is what staff test with day to day, so
+// the entry form opens on it; strips are the exception, not the norm.
+export const DEFAULT_TEST_METHOD: TestMethod = 'tf_pro_salt';
+
 // 'chlorine' throughout the engine means FREE chlorine (FC) — the active
 // sanitizer that strips report and the dosing chart targets. 'cc' is combined
 // chlorine (chloramines) — spent sanitizer, total minus free.


### PR DESCRIPTION
Follow-up to #136, which merged before this commit landed on the branch.

Staff test with the reagent kit day to day, but the water log entry form opened on "Test strips", so the method had to be reselected on nearly every entry.

## Changes

- `charts.ts`: new `DEFAULT_TEST_METHOD` constant set to `tf_pro_salt`, placed next to `TEST_METHODS` / `TEST_METHOD_LABELS` so the enum and its default live together.
- `WaterLog.tsx`: the `testMethod` state initializes from that constant instead of the inline `'strips'`.

The select still offers all three methods and the saved value is unchanged for existing rows — this only changes what a fresh form starts on.

## Note on naming

There is no option literally named "Taylor". The three methods are `strips`, `digital_meter`, and `tf_pro_salt` ("TF-Pro Salt") — I read "the Taylor kit" as TF-Pro Salt, since it is the only drop-reagent kit and it ships Taylor reagents. If a separate Taylor K-2006 should be its own option, that needs a new enum value plus a migration widening the `test_method` check constraint in `apps/supabase/migrations/20260804170000_water_tests_fc_cc_method.sql`.

## Verification

- `yarn biome check` — clean on both files.
- `yarn type-check` — 0 errors.
- `yarn test` — 42 passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5hFgFEYJkRPhDF7E8RcWp)_