### PR TITLE
Pass Vercel protection bypass on the agent server-to-server hops

### DIFF
--- a/apps/agents/.env.example
+++ b/apps/agents/.env.example
@@ -14,6 +14,12 @@ SUPABASE_AGENTS_SECRET_KEY=
 INTEGRATIONS_BASE_URL=http://localhost:4330
 AGENT_API_SECRET=
 
+# Only when INTEGRATIONS_BASE_URL points at a protected (preview/staging)
+# deployment: pyre-integrations' Protection Bypass for Automation secret,
+# from its Vercel project → Settings → Deployment Protection. Leave unset
+# locally and in production.
+INTEGRATIONS_PROTECTION_BYPASS=
+
 # Inbound auth for POST /eve/v1/session (the admin "Draft schedule" button
 # and any external trigger).
 EVE_CHANNEL_SECRET=

--- a/apps/agents/README.md
+++ b/apps/agents/README.md
@@ -61,9 +61,18 @@ without writing anything, set `AGENT_FORCE_DRY_RUN=1` and run
    AI Gateway enabled, env vars from `.env.example`.
 4. pyre-integrations env additions: `AGENT_API_SECRET`, `AGENTS_BASE_URL`
    (this app's deployment URL), `EVE_CHANNEL_SECRET`.
-5. Verify `GET /eve/v1/health`, then button-draft a future week from
+5. **Protected (preview/staging) deployments only.** Vercel Deployment
+   Protection 401s server-to-server calls at the edge, before either app's
+   own bearer check runs. For each protected side, Settings → Deployment
+   Protection → Protection Bypass for Automation → generate, then hand the
+   secret to the *caller*: pyre-agents' secret becomes
+   `AGENTS_PROTECTION_BYPASS` on pyre-integrations, and pyre-integrations'
+   becomes `INTEGRATIONS_PROTECTION_BYPASS` on pyre-agents. Both hops need it
+   — the button-draft call out and the `save_proposal` write back. Leave both
+   unset in production, where neither deployment is protected.
+6. Verify `GET /eve/v1/health`, then button-draft a future week from
    `/admin/schedule`.
-6. The weekly cron registers automatically on deploy (check Vercel
+7. The weekly cron registers automatically on deploy (check Vercel
    Observability → Cron Jobs). If plan limits block Vercel Cron, delete
    `agent/schedules/weekly_draft.md` and add a QStash schedule (or a
    `CRON_JOBS` entry in integrations) POSTing the same `/eve/v1/session`

--- a/apps/agents/agent/lib/api.ts
+++ b/apps/agents/agent/lib/api.ts
@@ -11,11 +11,18 @@ export async function postProposal(body: Record<string, unknown>): Promise<{
     throw new Error('Integrations API not configured (INTEGRATIONS_BASE_URL / AGENT_API_SECRET)');
   }
 
+  // Preview/staging deployments of pyre-integrations sit behind Vercel
+  // Deployment Protection, which 401s at the edge before AGENT_API_SECRET is
+  // ever checked. The bypass secret clears that layer only — the bearer above
+  // is still what authenticates the write.
+  const bypass = process.env.INTEGRATIONS_PROTECTION_BYPASS;
+
   const response = await fetch(`${baseUrl}/api/agent/proposals`, {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${secret}`,
       'Content-Type': 'application/json',
+      ...(bypass ? { 'x-vercel-protection-bypass': bypass } : {}),
     },
     body: JSON.stringify(body),
   });
@@ -26,5 +33,17 @@ export async function postProposal(body: Record<string, unknown>): Promise<{
   } catch {
     parsed = { error: `Non-JSON response (HTTP ${response.status})` };
   }
+
+  // Deployment Protection answers with its own JSON envelope, whose `error` is
+  // an object — surface it as a string so the failure reads as a deploy-config
+  // problem rather than a validation one.
+  if ('protection' in parsed) {
+    parsed = {
+      error:
+        'Blocked by Vercel Deployment Protection before reaching the integrations API. ' +
+        'Set INTEGRATIONS_PROTECTION_BYPASS on this deployment.',
+    };
+  }
+
   return { status: response.status, body: parsed };
 }

--- a/apps/integrations/.env.example
+++ b/apps/integrations/.env.example
@@ -50,3 +50,13 @@ ADMIN_EMAILS=you@example.com
 # queries) plus the numeric project id.
 POSTHOG_PERSONAL_API_KEY=your_personal_api_key
 POSTHOG_PROJECT_ID=your_numeric_project_id
+
+# --- pyre-agents (Eve staff-scheduling drafter) ---
+# Deployment URL + the bearer its channel auth expects on /eve/v1/session.
+# Locally this is whatever port `yarn workspace pyre-agents dev` reports.
+AGENTS_BASE_URL=http://localhost:PORT
+EVE_CHANNEL_SECRET=your_eve_channel_secret
+# Only when AGENTS_BASE_URL is a protected preview/staging deployment: the
+# pyre-agents Protection Bypass for Automation secret (Vercel project →
+# Settings → Deployment Protection). Leave unset locally and in production.
+AGENTS_PROTECTION_BYPASS=

--- a/apps/integrations/src/env.d.ts
+++ b/apps/integrations/src/env.d.ts
@@ -82,6 +82,14 @@ interface ImportMetaEnv {
   readonly PUBLIC_SITE_URL?: string;
   // Base URL for hosted email images (defaults to this app's production deployment)
   readonly PUBLIC_EMAIL_ASSET_BASE?: string;
+  // pyre-agents (Eve): deployment URL + the bearer the agent's channel auth
+  // expects on POST /eve/v1/session.
+  readonly AGENTS_BASE_URL?: string;
+  readonly EVE_CHANNEL_SECRET?: string;
+  // pyre-agents' Protection Bypass for Automation secret — required only when
+  // AGENTS_BASE_URL is a protected (preview/staging) deployment, which 401s at
+  // the edge before EVE_CHANNEL_SECRET is checked.
+  readonly AGENTS_PROTECTION_BYPASS?: string;
 }
 
 interface ImportMeta {

--- a/apps/integrations/src/pages/api/admin/schedule-draft.ts
+++ b/apps/integrations/src/pages/api/admin/schedule-draft.ts
@@ -32,6 +32,12 @@ export const POST: APIRoute = async ({ cookies, request }) => {
     return json({ error: 'Agent not configured (AGENTS_BASE_URL / EVE_CHANNEL_SECRET)' }, 503);
   }
 
+  // Preview/staging deployments of pyre-agents sit behind Vercel Deployment
+  // Protection, which 401s at the edge before EVE_CHANNEL_SECRET is ever
+  // checked. The bypass secret gets us past that layer only — the channel
+  // secret above is still what authenticates us to the agent.
+  const agentsBypass = import.meta.env.AGENTS_PROTECTION_BYPASS;
+
   let body: Record<string, unknown> = {};
   try {
     if (request.headers.get('content-type')?.includes('application/json')) {
@@ -65,6 +71,7 @@ export const POST: APIRoute = async ({ cookies, request }) => {
     headers: {
       Authorization: `Bearer ${channelSecret}`,
       'Content-Type': 'application/json',
+      ...(agentsBypass ? { 'x-vercel-protection-bypass': agentsBypass } : {}),
     },
     body: JSON.stringify({
       message: `Draft the staffing schedule for the week starting ${weekStart}. Use get_week_context with weekStart "${weekStart}", then save exactly one proposal. Any previous draft for that week is superseded automatically.`,


### PR DESCRIPTION
## Problem

Triggering the agent from staging fails before any application code runs:

```
Agent session failed (HTTP 401): {"error":{"code":"401","message":"Protected deployment"},
"protection":{"vercel_auth_enabled":true, ...}}
```

Vercel Deployment Protection answers preview/staging requests with an SSO challenge at the edge. The request never reaches `channelSecretAuth()` in `apps/agents/agent/channels/eve.ts`, so `EVE_CHANNEL_SECRET` is irrelevant to the failure — this is a transport-layer block, not an auth mismatch.

The same wall sits on the **return leg**: `save_proposal` → `postProposal()` → `POST {integrations}/api/agent/proposals`. Fixing only the outbound call would have moved the failure one step later, into the middle of an agent run.

## Changes

- `apps/integrations/src/pages/api/admin/schedule-draft.ts` — send `x-vercel-protection-bypass` on the `/eve/v1/session` call when `AGENTS_PROTECTION_BYPASS` is set.
- `apps/agents/agent/lib/api.ts` — same for the proposal write back, keyed on `INTEGRATIONS_PROTECTION_BYPASS`.
- `apps/agents/agent/lib/api.ts` — collapse the protection response's nested `error` object into a readable string, so the failure reads as a deploy-config problem rather than a validation one.
- Env docs: `apps/agents/.env.example`, `apps/integrations/.env.example`, `apps/integrations/src/env.d.ts` (which also picks up the previously undeclared `AGENTS_BASE_URL` / `EVE_CHANNEL_SECRET`).
- `apps/agents/README.md` — new deploy-checklist step covering both directions.

The bypass header clears the edge layer only. `EVE_CHANNEL_SECRET` and `AGENT_API_SECRET` still authenticate both calls, and each header is omitted entirely when its secret is unset — so local dev and production (unprotected) behave exactly as before.

## Setup required before this works on staging

For each protected project, Vercel → Settings → Deployment Protection → Protection Bypass for Automation → generate, then give the secret to the **caller**:

| Secret generated on | Set as | On project |
|---|---|---|
| pyre-agents | `AGENTS_PROTECTION_BYPASS` | pyre-integrations |
| pyre-integrations | `INTEGRATIONS_PROTECTION_BYPASS` | pyre-agents |

## Testing

- `yarn workspace @pyre/integrations type-check` — 0 errors (2 pre-existing hints in an unrelated email template).
- `tsc --noEmit` in `apps/agents` — clean.
- `biome check` on the changed integrations files — clean. `apps/agents` has no Biome config or lint script, so it is outside that pipeline.
- Not exercised end-to-end against staging — that needs the two bypass secrets above to exist first.
