### PR TITLE
Water log times + CSV export, and one-per-type session labels on the staff schedule

### DIFF
--- a/apps/integrations/src/components/admin/ScheduleBoard.tsx
+++ b/apps/integrations/src/components/admin/ScheduleBoard.tsx
@@ -14,6 +14,7 @@ import {
   assignmentHours,
   availabilityFor,
   DOW_LABELS,
+  formatShiftNotes,
   minutesToTime,
   SHIFT_LABEL_SUGGESTIONS,
   timeToMinutes,
@@ -494,6 +495,7 @@ export function ScheduleBoard() {
               <div className="space-y-2">
                 {shifts.map((shift) => {
                   const tone = coverageTone(shift);
+                  const notes = formatShiftNotes(shift);
                   const expanded = canManage
                     ? expandedId === shift.id
                     : !collapsedIds.has(shift.id);
@@ -549,8 +551,8 @@ export function ScheduleBoard() {
                               </Fragment>
                             ))}
                           </span>
-                          {shift.notes && (
-                            <span className="font-mono text-xs text-white/40">{shift.notes}</span>
+                          {notes && (
+                            <span className="font-mono text-xs text-white/40">{notes}</span>
                           )}
                         </button>
                         {shift.is_draft && (

--- a/apps/integrations/src/components/admin/ScheduleCalendar.tsx
+++ b/apps/integrations/src/components/admin/ScheduleCalendar.tsx
@@ -8,6 +8,7 @@
 import {
   addDays,
   busyIntervalsFor,
+  formatShiftNotes,
   minutesToTime,
   timeToMinutes,
   weekStartOf,
@@ -309,11 +310,12 @@ export function ScheduleCalendar() {
                         const names = assigned
                           .map((a) => staffById.get(a.staff_id)?.display_name ?? '?')
                           .join(', ');
+                        const notes = formatShiftNotes(shift);
                         return (
                           <a
                             key={shift.id}
                             href="/admin/schedule"
-                            title={`${shift.label} ${formatTime(shift.starts_at)}–${formatTime(shift.ends_at)} · ${shift.assignments.length}/${shift.staff_needed}${names ? ` · ${names}` : ''}${shift.notes ? ` · ${shift.notes}` : ''}`}
+                            title={`${shift.label} ${formatTime(shift.starts_at)}–${formatTime(shift.ends_at)} · ${shift.assignments.length}/${shift.staff_needed}${names ? ` · ${names}` : ''}${notes ? ` · ${notes}` : ''}`}
                             className={`block overflow-hidden rounded border px-1.5 py-1 ${toneBlock[coverageTone(shift)]}`}
                           >
                             <span className="block truncate text-[11px] font-semibold leading-tight">

--- a/apps/integrations/src/components/admin/WaterLog.tsx
+++ b/apps/integrations/src/components/admin/WaterLog.tsx
@@ -113,20 +113,25 @@ const ENTRY_TYPE_LABELS: Array<[EntryType, string]> = [
   ['refill', 'Drain / Refill'],
 ];
 
-function TimeAgo({ iso }: { iso: string }) {
-  const timestamp = Date.parse(iso);
-  const diff = Date.now() - timestamp;
-  const mins = Math.floor(diff / 60_000);
-  const hours = Math.floor(diff / 3_600_000);
-  const days = Math.floor(diff / 86_400_000);
+// Staff read the log to answer "when was this tub last tested?", so entries
+// carry the clock time they were taken rather than an elapsed-time marker.
+// Rendered in the viewer's locale/timezone, which differs from the server's on
+// first paint — hence suppressHydrationWarning.
+const TIMESTAMP_FORMAT: Intl.DateTimeFormatOptions = {
+  weekday: 'short',
+  month: 'short',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: '2-digit',
+};
 
-  let label: string;
-  if (mins < 1) label = 'just now';
-  else if (mins < 60) label = `${mins}m ago`;
-  else if (hours < 24) label = `${hours}h ago`;
-  else label = `${days}d ago`;
-
-  return <span title={new Date(timestamp).toLocaleString()}>{label}</span>;
+function RecordedAt({ iso }: { iso: string }) {
+  const timestamp = new Date(iso);
+  return (
+    <span suppressHydrationWarning title={timestamp.toLocaleString()}>
+      {timestamp.toLocaleString(undefined, TIMESTAMP_FORMAT)}
+    </span>
+  );
 }
 
 const statusTint: Record<ReturnType<typeof classifyReading>, string> = {
@@ -269,6 +274,7 @@ export function WaterLog({ userEmail }: { userEmail: string }) {
   const [logLoading, setLogLoading] = useState(false);
   const [logError, setLogError] = useState('');
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [exporting, setExporting] = useState(false);
 
   // --- trends chart ---
   const [range, setRange] = useState<RangeKey>('30d');
@@ -475,6 +481,38 @@ export function WaterLog({ userEmail }: { userEmail: string }) {
       setFormError(err instanceof Error ? err.message : 'Failed to save');
     } finally {
       setSaving(false);
+    }
+  };
+
+  // CSV of everything matching the current range/tub filters — not just the
+  // pages loaded below. Fetched rather than linked so an expired session lands
+  // on the re-login prompt instead of downloading an error body.
+  const exportCsv = async () => {
+    setExporting(true);
+    setLogError('');
+    try {
+      const params = new URLSearchParams({ format: 'csv' });
+      if (filter !== 'all') params.set('tub', filter);
+      const since = sinceIso(range);
+      if (since) params.set('since', since);
+      const res = await fetch(`/api/admin/water-tests?${params}`);
+      if (res.status === 401 || res.status === 403) {
+        setSessionExpired(true);
+        return;
+      }
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const url = URL.createObjectURL(await res.blob());
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `water-log-${filter}-${range}-${new Date().toISOString().slice(0, 10)}.csv`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      setLogError(err instanceof Error ? err.message : 'Failed to export CSV');
+    } finally {
+      setExporting(false);
     }
   };
 
@@ -830,7 +868,18 @@ export function WaterLog({ userEmail }: { userEmail: string }) {
       </details>
 
       {/* ---- Log ---- */}
-      <h2 className="mb-4 font-primary-semibold text-lg">Log</h2>
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <h2 className="font-primary-semibold text-lg">Log</h2>
+        <button
+          type="button"
+          onClick={() => void exportCsv()}
+          disabled={exporting}
+          title="Downloads every entry matching the range and tub filters above"
+          className="rounded border border-white/10 bg-white/5 px-3 py-2 font-mono-bold text-xs uppercase tracking-wide text-white/50 transition-colors hover:border-white/30 hover:text-white disabled:opacity-50"
+        >
+          {exporting ? 'Exporting…' : 'Export CSV'}
+        </button>
+      </div>
 
       {logError && <p className="mb-3 text-sm text-[var(--pyre-red)]">{logError}</p>}
       {!logError && records.length === 0 && !logLoading && (
@@ -849,7 +898,7 @@ export function WaterLog({ userEmail }: { userEmail: string }) {
               </span>
             )}
             <span className="ml-auto font-mono text-xs text-white/40">
-              <TimeAgo iso={record.created_at} />
+              <RecordedAt iso={record.created_at} />
             </span>
           </div>
 

--- a/apps/integrations/src/lib/water/csv.test.ts
+++ b/apps/integrations/src/lib/water/csv.test.ts
@@ -1,0 +1,74 @@
+// The export is what leaves the app for a spreadsheet, so the escaping rules
+// (quoting, formula defusing) and the column contract get pinned here.
+
+import { describe, expect, it } from 'vitest';
+import type { WaterTestRow } from '@/lib/db';
+import { waterTestsToCsv } from './csv';
+
+const record = (over: Partial<WaterTestRow> = {}): WaterTestRow => ({
+  id: 'row-1',
+  tub: 'left',
+  entry_type: 'test',
+  ta_ppm: 90,
+  ph: 7.4,
+  free_chlorine_ppm: 2,
+  combined_chlorine_ppm: 0.2,
+  salt_ppm: 3200,
+  test_method: 'tf_pro_salt',
+  doses: [],
+  notes: null,
+  recorded_by: 'staff@pyresauna.com',
+  created_at: '2026-08-09T14:12:00.000Z',
+  updated_at: '2026-08-09T14:12:00.000Z',
+  ...over,
+});
+
+const rows = (csv: string) => csv.replace('\uFEFF', '').trimEnd().split('\r\n');
+
+describe('waterTestsToCsv', () => {
+  it('writes a header and one row per entry', () => {
+    const [header, first] = rows(waterTestsToCsv([record()]));
+    expect(header).toBe(
+      'Recorded at,Tub,Entry type,TA (ppm),pH,Free chlorine (ppm),Combined chlorine (ppm),Salt (ppm),Test method,Added to water,Notes,Recorded by'
+    );
+    expect(first).toBe(
+      '2026-08-09T14:12:00.000Z,left,test,90,7.4,2,0.2,3200,TF-Pro Salt,,,staff@pyresauna.com'
+    );
+  });
+
+  it('leaves untested readings blank rather than zero', () => {
+    const [, row] = rows(waterTestsToCsv([record({ ta_ppm: null, salt_ppm: null })]));
+    expect(row.split(',').slice(3, 8)).toEqual(['', '7.4', '2', '0.2', '']);
+  });
+
+  it('flattens doses into one cell', () => {
+    const [, row] = rows(
+      waterTestsToCsv([
+        record({
+          entry_type: 'shock',
+          doses: [
+            { chemical: 'Cold Water Sanitizer', grams: 30 },
+            { chemical: 'Dead Sea Salt', grams: 200 },
+          ],
+        }),
+      ])
+    );
+    expect(row).toContain('Cold Water Sanitizer 30 g; Dead Sea Salt 200 g');
+  });
+
+  it('quotes notes containing commas, quotes, and newlines', () => {
+    const [, row] = rows(waterTestsToCsv([record({ notes: 'Cloudy, said "hazy"' })]));
+    expect(row).toContain('"Cloudy, said ""hazy"""');
+  });
+
+  it('defuses notes a spreadsheet would run as a formula', () => {
+    const [, row] = rows(waterTestsToCsv([record({ notes: '=SUM(A1:A9)' })]));
+    expect(row).toContain("'=SUM(A1:A9)");
+  });
+
+  it('starts with a BOM and ends every line with CRLF', () => {
+    const csv = waterTestsToCsv([record()]);
+    expect(csv.startsWith('\uFEFF')).toBe(true);
+    expect(csv.endsWith('\r\n')).toBe(true);
+  });
+});

--- a/apps/integrations/src/lib/water/csv.ts
+++ b/apps/integrations/src/lib/water/csv.ts
@@ -1,0 +1,43 @@
+// CSV serialization for the cold-tub water log export. Kept out of the API
+// route so the escaping rules are unit-testable; the route only decides which
+// rows to hand over.
+
+import type { WaterTestRow } from '@/lib/db';
+import { TEST_METHOD_LABELS } from './charts';
+
+const COLUMNS: Array<[string, (row: WaterTestRow) => string | number | null]> = [
+  ['Recorded at', (r) => r.created_at],
+  ['Tub', (r) => r.tub],
+  ['Entry type', (r) => r.entry_type],
+  ['TA (ppm)', (r) => r.ta_ppm],
+  ['pH', (r) => r.ph],
+  ['Free chlorine (ppm)', (r) => r.free_chlorine_ppm],
+  ['Combined chlorine (ppm)', (r) => r.combined_chlorine_ppm],
+  ['Salt (ppm)', (r) => r.salt_ppm],
+  ['Test method', (r) => (r.test_method ? TEST_METHOD_LABELS[r.test_method] : null)],
+  ['Added to water', (r) => r.doses.map((d) => `${d.chemical} ${d.grams} g`).join('; ')],
+  ['Notes', (r) => r.notes],
+  ['Recorded by', (r) => r.recorded_by],
+];
+
+/**
+ * One CSV cell: quote anything that would otherwise break the row, and defuse
+ * leading characters a spreadsheet would read as a formula (the log carries
+ * staff-typed notes).
+ */
+function cell(value: string | number | null): string {
+  if (value == null) return '';
+  if (typeof value === 'number') return String(value);
+  const text = /^[=+@\t\r]/.test(value) ? `'${value}` : value;
+  return /[",\r\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
+}
+
+/** Header row plus one line per entry, in the order given. */
+export function waterTestsToCsv(records: readonly WaterTestRow[]): string {
+  const lines = [COLUMNS.map(([header]) => cell(header)).join(',')];
+  for (const record of records) {
+    lines.push(COLUMNS.map(([, read]) => cell(read(record))).join(','));
+  }
+  // Leading BOM so Excel opens the file as UTF-8; CRLF line breaks per RFC 4180.
+  return `\uFEFF${lines.join('\r\n')}\r\n`;
+}

--- a/apps/integrations/src/pages/api/admin/water-tests.ts
+++ b/apps/integrations/src/pages/api/admin/water-tests.ts
@@ -1,8 +1,8 @@
 // Cold-tub water testing log API for the /admin/water staff tool: GET lists
-// entries newest-first (optionally per tub), POST records a new entry with
-// readings and the chemicals actually added, DELETE removes an entry the
-// caller recorded themselves. Gated on the /admin/water page grant
-// (requirePage), and — as the app's
+// entries newest-first (optionally per tub, or as a CSV download with
+// ?format=csv), POST records a new entry with readings and the chemicals
+// actually added, DELETE removes an entry the caller recorded themselves.
+// Gated on the /admin/water page grant (requirePage), and — as the app's
 // first cookie-authed mutating routes — CSRF-guarded in-route via
 // assertSameOrigin plus (on POST) the JSON content-type requirement (global
 // checkOrigin stays off for the Mailchimp webhook; see astro.config.mjs).
@@ -18,6 +18,7 @@ import {
   TUBS,
   type Tub,
 } from '@/lib/water/charts';
+import { waterTestsToCsv } from '@/lib/water/csv';
 
 const JSON_HEADERS = { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' };
 
@@ -27,6 +28,10 @@ function json(body: unknown, status = 200): Response {
 
 const MAX_LIMIT = 100;
 const DEFAULT_LIMIT = 25;
+// The export ignores the paging limits — one file should hold the whole
+// filtered history — but stays bounded so a runaway table can't blow the
+// function's memory.
+const CSV_MAX_ROWS = 5000;
 
 // Sanity bounds only (mirrors the table's check constraints); target-range
 // logic lives in src/lib/water/.
@@ -63,6 +68,31 @@ export const GET: APIRoute = async ({ cookies, url }) => {
   const since = url.searchParams.get('since');
   if (since && Number.isNaN(Date.parse(since))) {
     return json({ error: 'since must be an ISO date' }, 400);
+  }
+
+  // CSV export: same tub/since filters as the log, but the whole matching
+  // history in one file (oldest first — a log people read top-to-bottom or
+  // chart in a spreadsheet).
+  if (url.searchParams.get('format') === 'csv') {
+    let csvQuery = db
+      .from('water_tests')
+      .select('*')
+      .order('created_at', { ascending: true })
+      .limit(CSV_MAX_ROWS);
+    if (tub) csvQuery = csvQuery.eq('tub', tub);
+    if (since) csvQuery = csvQuery.gte('created_at', since);
+
+    const { data: csvRows, error: csvError } = await csvQuery;
+    if (csvError) return json({ error: csvError.message }, 500);
+
+    const filename = `water-log-${tub ?? 'all'}-${new Date().toISOString().slice(0, 10)}.csv`;
+    return new Response(waterTestsToCsv((csvRows ?? []) as WaterTestRow[]), {
+      headers: {
+        'Content-Type': 'text/csv; charset=utf-8',
+        'Content-Disposition': `attachment; filename="${filename}"`,
+        'Cache-Control': 'no-store',
+      },
+    });
   }
 
   const limit = Math.min(

--- a/packages/schedule-core/src/windows.ts
+++ b/packages/schedule-core/src/windows.ts
@@ -41,7 +41,11 @@ export interface CoverageWindow {
   label: string;
   staffNeeded: number;
   sessionRefs: Array<{ type: 'session' | 'appointment'; id: number }>;
-  /** Titles of the covered events, for shift notes/debugging. */
+  /**
+   * Distinct titles of the covered events in first-seen order, for shift
+   * notes/debugging. A day of hourly Open Hours slots is one session type, not
+   * six — the count lives in sessionRefs.
+   */
   titles: string[];
 }
 
@@ -93,7 +97,7 @@ export function deriveCoverageWindows(
         currentPaddedEnd = Math.max(currentPaddedEnd, paddedEnd);
         current.endMin = ceilHalfHour(currentPaddedEnd);
         current.sessionRefs.push({ type: event.kind, id: event.id });
-        current.titles.push(event.title);
+        if (!current.titles.includes(event.title)) current.titles.push(event.title);
       } else {
         current = {
           date,
@@ -117,6 +121,26 @@ export function deriveCoverageWindows(
   }
 
   return windows;
+}
+
+/**
+ * Notes on a Momence-sourced shift are the window's comma-joined session
+ * titles, so the schedule should read "Open Hours, Yoga" however many slots of
+ * each the day holds. Titles are deduped at derivation now, but rows written
+ * before that still repeat — collapse them on the way to the screen. Manual
+ * notes are free text and pass through untouched.
+ */
+export function formatShiftNotes(shift: {
+  source: 'momence' | 'manual';
+  notes: string | null;
+}): string | null {
+  if (!shift.notes || shift.source !== 'momence') return shift.notes;
+  const seen = new Set<string>();
+  for (const part of shift.notes.split(',')) {
+    const title = part.trim();
+    if (title) seen.add(title);
+  }
+  return seen.size > 0 ? [...seen].join(', ') : shift.notes;
 }
 
 // --- Sync planning: diff derived windows against existing shifts ---

--- a/packages/schedule-core/test/windows.test.ts
+++ b/packages/schedule-core/test/windows.test.ts
@@ -7,6 +7,7 @@ import {
   type CoverageEvent,
   DEFAULT_WINDOW_OPTIONS,
   deriveCoverageWindows,
+  formatShiftNotes,
   labelForWindow,
   planShiftSync,
   type SyncShiftInput,
@@ -92,6 +93,18 @@ describe('deriveCoverageWindows', () => {
     expect(windows[1].startMin).toBe(0);
   });
 
+  it('lists each session type once, however many slots of it the window holds', () => {
+    const windows = deriveCoverageWindows([
+      event({ id: 1, title: 'Open Hours', startMin: min('12:00'), endMin: min('13:00') }),
+      event({ id: 2, title: 'Open Hours', startMin: min('13:00'), endMin: min('14:00') }),
+      event({ id: 3, title: 'Yoga', startMin: min('14:00'), endMin: min('15:00') }),
+      event({ id: 4, title: 'Open Hours', startMin: min('15:00'), endMin: min('16:00') }),
+    ]);
+    expect(windows).toHaveLength(1);
+    expect(windows[0].titles).toEqual(['Open Hours', 'Yoga']);
+    expect(windows[0].sessionRefs).toHaveLength(4);
+  });
+
   it('interleaves appointments with sessions in the same window', () => {
     const windows = deriveCoverageWindows([
       event({ id: 1, startMin: min('16:00'), endMin: min('17:00') }),
@@ -102,6 +115,24 @@ describe('deriveCoverageWindows', () => {
       { type: 'session', id: 1 },
       { type: 'appointment', id: 9 },
     ]);
+  });
+});
+
+describe('formatShiftNotes', () => {
+  it('collapses repeated session titles on momence shifts', () => {
+    expect(
+      formatShiftNotes({
+        source: 'momence',
+        notes: 'Open Hours, Open Hours, Yoga, Open Hours',
+      })
+    ).toBe('Open Hours, Yoga');
+  });
+
+  it('leaves manual notes and empty notes alone', () => {
+    expect(formatShiftNotes({ source: 'manual', notes: 'Deep clean, deep clean' })).toBe(
+      'Deep clean, deep clean'
+    );
+    expect(formatShiftNotes({ source: 'momence', notes: null })).toBeNull();
   });
 });
 


### PR DESCRIPTION
Three edits to the integrations admin tools.

### Water log shows when a reading was taken
Entries carried an elapsed-time marker (`3h ago`, `2d ago`), which doesn't answer "was this morning's test done?" without arithmetic. Each entry now prints the clock time it was recorded — `Sat, Aug 9, 2:14 PM` — in the viewer's timezone, with the full timestamp on hover.

### Water log CSV export
New **Export CSV** button beside the Log heading. It downloads every entry matching the current range and tub filters — not just the pages loaded on screen — via `GET /api/admin/water-tests?format=csv`, oldest first, capped at 5000 rows.

Columns: recorded at, tub, entry type, TA, pH, free chlorine, combined chlorine, salt, test method, added to water, notes, recorded by.

Serialization lives in `apps/integrations/src/lib/water/csv.ts` so the escaping rules are unit-tested: RFC 4180 quoting and CRLF line breaks, doubled quotes, a UTF-8 BOM for Excel, and a leading apostrophe on staff notes a spreadsheet would otherwise evaluate as a formula. The export is fetched rather than linked so an expired session lands on the re-login prompt instead of downloading an error body.

### Staff schedule lists each session type once
A day of hourly Open Hours plus a yoga class read as `Open Hours, Open Hours, Open Hours, Yoga` — effectively a slot count. `deriveCoverageWindows` now keeps distinct titles in first-seen order, so new shifts read `Open Hours, Yoga`; the slot count still lives in `sessionRefs`.

Shift rows written before this change still hold repeated notes, so `formatShiftNotes` collapses them on the way to the screen (week board and month calendar) for Momence-sourced shifts. Manual, admin-typed notes pass through untouched.

### Checks
`yarn workspace @pyre/schedule-core test`, `yarn workspace @pyre/integrations test` (48 passing, including the new CSV and dedupe cases), `type-check`, `biome check` on the changed files, and `astro build` all pass.

### Note on scope
This branch stacks on earlier integrations work that hasn't landed on `master` yet, so the diff against `master` is larger than the three edits above — those are commit `04a9d79`.