### PR TITLE
Add Qi Gong filter to landing page events

### DIFF
--- a/apps/landing-page/src/lib/events-config.ts
+++ b/apps/landing-page/src/lib/events-config.ts
@@ -15,7 +15,15 @@ export const SPECIAL_EVENT_TAG = 'Special Event';
 // A chip is shown only if at least one upcoming event in the window carries the
 // tag. Matching against events is case-insensitive; these canonical strings are
 // used for the chip label and the ?type= URL value.
-export const CATEGORY_TAGS = ['Guided', 'Social', SPECIAL_EVENT_TAG, 'Yoga', 'Breathwork', 'Open Hours'];
+export const CATEGORY_TAGS = [
+  'Guided',
+  'Social',
+  SPECIAL_EVENT_TAG,
+  'Yoga',
+  'Breathwork',
+  'Qi Gong',
+  'Open Hours',
+];
 
 // Whether an event carries the Special Event tag (case-insensitive). Pure helper
 // shared by the client grid and the /api/events route so special events bypass


### PR DESCRIPTION
## Summary
Adds a **Qi Gong** filter chip to the events page, driven by the Momence tag "Qi Gong".

One-line config change: adds `'Qi Gong'` to `CATEGORY_TAGS` in `apps/landing-page/src/lib/events-config.ts` (placed between Breathwork and Open Hours in chip display order). The existing grid logic handles the rest — the chip only renders when an upcoming event in the 2-week window carries the tag, tag matching is case-insensitive, and the chip is deep-linkable via `?type=Qi%20Gong`.

## Testing
Verified locally against live Momence data: the QI GONG chip appears on `/events`, and selecting it filters the list to the tagged session ("Qi Gong // Sauna // Plunge w/ Shi Heng Chou", Thu Aug 20).