### PR TITLE
Add customer referral program

### DIFF
--- a/apps/integrations/src/components/admin/ReferralsManager.tsx
+++ b/apps/integrations/src/components/admin/ReferralsManager.tsx
@@ -1,0 +1,609 @@
+// Referral program management: the referrer registry (member + partner codes),
+// the redemption queue, the reward ledger, and the discount tier map. One API
+// route; the manage capability gates every mutation, so a read-only grant
+// still gets the full picture.
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type {
+  ReferralRedemptionRow,
+  ReferralRewardRow,
+  ReferralTierRow,
+  ReferrerRow,
+} from '@/lib/db';
+
+const inputClass =
+  'px-3 py-2 rounded bg-white/5 border border-white/10 text-sm text-[var(--pyre-creme)] placeholder-white/30 focus:outline-none focus:border-white/30';
+
+const buttonClass =
+  'px-3 py-1.5 rounded border border-white/10 bg-white/5 text-xs font-mono uppercase tracking-wide text-white/70 hover:border-white/30 hover:text-white transition-colors disabled:opacity-40';
+
+const pillClass = (active: boolean) =>
+  `px-2.5 py-1.5 rounded text-xs font-mono uppercase tracking-wide border transition-colors ${
+    active
+      ? 'border-[var(--pyre-red)] bg-[var(--pyre-red)]/15 text-[var(--pyre-creme)]'
+      : 'border-white/10 bg-white/5 text-white/50 hover:border-white/30 hover:text-white'
+  }`;
+
+const sectionHeading = 'font-mono text-xs font-bold uppercase tracking-wide text-white/40';
+const card = 'rounded-lg border border-white/10 bg-white/[0.03] p-3';
+
+interface ReferralsPayload {
+  referrers: ReferrerRow[];
+  redemptions: ReferralRedemptionRow[];
+  rewards: ReferralRewardRow[];
+  tiers: ReferralTierRow[];
+  rewardTagName: string;
+  tagStatus: Record<string, boolean | null>;
+  counts: Record<string, number>;
+  canManage: boolean;
+}
+
+async function readError(res: Response): Promise<string> {
+  try {
+    return ((await res.json()) as { error?: string }).error ?? `HTTP ${res.status}`;
+  } catch {
+    return `HTTP ${res.status}`;
+  }
+}
+
+const fmtDate = (iso: string | null): string =>
+  iso ? new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) : '—';
+
+const STATUS_COLORS: Record<string, string> = {
+  pending: 'text-yellow-300/80',
+  redeemed: 'text-blue-300/80',
+  converted: 'text-green-300/80',
+  granted: 'text-blue-300/80',
+  consumed: 'text-green-300/80',
+  expired: 'text-white/40',
+  revoked: 'text-[var(--pyre-red)]',
+};
+
+const REDEMPTION_FILTERS = ['all', 'pending', 'redeemed', 'converted', 'expired', 'revoked'];
+
+export function ReferralsManager() {
+  const [data, setData] = useState<ReferralsPayload | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [search, setSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState('all');
+  // Search is applied on submit (and carried along when the filter changes),
+  // not per keystroke — the ref keeps the effect below off the input's back.
+  const searchRef = useRef('');
+  searchRef.current = search;
+
+  const load = useCallback(async (q: string, status: string) => {
+    const params = new URLSearchParams();
+    if (q) params.set('q', q);
+    if (status !== 'all') params.set('status', status);
+    try {
+      const res = await fetch(`/api/admin/referrals?${params}`);
+      if (!res.ok) {
+        setLoadError(await readError(res));
+        return;
+      }
+      setData((await res.json()) as ReferralsPayload);
+      setLoadError(null);
+    } catch {
+      setLoadError('Failed to load');
+    }
+  }, []);
+
+  useEffect(() => {
+    load(searchRef.current, statusFilter);
+  }, [load, statusFilter]);
+
+  const act = useCallback(
+    async (body: Record<string, unknown>, successNotice?: string) => {
+      setBusy(true);
+      setActionError(null);
+      setNotice(null);
+      try {
+        const res = await fetch('/api/admin/referrals', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+        if (!res.ok) {
+          setActionError(await readError(res));
+          return false;
+        }
+        if (successNotice) setNotice(successNotice);
+        await load(search, statusFilter);
+        return true;
+      } catch {
+        setActionError('Request failed');
+        return false;
+      } finally {
+        setBusy(false);
+      }
+    },
+    [load, search, statusFilter]
+  );
+
+  if (loadError) {
+    return <p className="font-mono text-sm text-[var(--pyre-red)]">{loadError}</p>;
+  }
+  if (!data) {
+    return <p className="font-mono text-sm text-white/40">Loading…</p>;
+  }
+
+  const referrersById = new Map(data.referrers.map((r) => [r.id, r]));
+  const canManage = data.canManage;
+
+  return (
+    <div className="space-y-8">
+      {actionError && (
+        <p className="font-mono text-sm text-[var(--pyre-red)]" role="alert">
+          {actionError}
+        </p>
+      )}
+      {notice && (
+        <p className="font-mono text-sm text-green-300/80" role="status">
+          {notice}
+        </p>
+      )}
+
+      <TiersSection
+        tiers={data.tiers}
+        rewardTagName={data.rewardTagName}
+        tagStatus={data.tagStatus}
+        canManage={canManage}
+        busy={busy}
+        act={act}
+      />
+
+      <ReferrersSection
+        referrers={data.referrers}
+        tiers={data.tiers}
+        canManage={canManage}
+        busy={busy}
+        act={act}
+        search={search}
+        setSearch={setSearch}
+        onSearch={() => load(search, statusFilter)}
+      />
+
+      <RedemptionsSection
+        redemptions={data.redemptions}
+        counts={data.counts}
+        referrersById={referrersById}
+        canManage={canManage}
+        busy={busy}
+        act={act}
+        statusFilter={statusFilter}
+        setStatusFilter={setStatusFilter}
+      />
+
+      <RewardsSection
+        rewards={data.rewards}
+        referrersById={referrersById}
+        canManage={canManage}
+        busy={busy}
+        act={act}
+      />
+    </div>
+  );
+}
+
+type Act = (body: Record<string, unknown>, successNotice?: string) => Promise<boolean>;
+
+function TiersSection({
+  tiers,
+  rewardTagName,
+  tagStatus,
+  canManage,
+  busy,
+  act,
+}: {
+  tiers: ReferralTierRow[];
+  rewardTagName: string;
+  tagStatus: Record<string, boolean | null>;
+  canManage: boolean;
+  busy: boolean;
+  act: Act;
+}) {
+  const [percent, setPercent] = useState('');
+  const [tagName, setTagName] = useState('');
+
+  const tagBadge = (name: string) => {
+    const status = tagStatus[name];
+    if (status === true) return <span className="text-green-300/80">tag ok</span>;
+    if (status === false)
+      return <span className="text-[var(--pyre-red)]">tag missing in Momence</span>;
+    return <span className="text-white/40">tag unchecked</span>;
+  };
+
+  return (
+    <section className="space-y-3">
+      <h2 className={sectionHeading}>Discount tiers</h2>
+      <p className="text-xs text-white/40 max-w-2xl">
+        Each tier needs its Momence customer tag AND a price rule keyed on that tag, both created by
+        hand in the Momence dashboard before the tier works. The reward tag ({rewardTagName}) needs
+        its own price rule the same way. After creating a tag in Momence, refresh the tag cache.
+      </p>
+      <div className="flex flex-wrap gap-2">
+        {tiers.map((tier) => (
+          <div key={tier.percent} className={`${card} flex items-center gap-3`}>
+            <span className="font-mono text-sm text-[var(--pyre-creme)]">{tier.percent}%</span>
+            <span className="font-mono text-xs text-white/50">{tier.tag_name}</span>
+            <span className="font-mono text-xs">{tagBadge(tier.tag_name)}</span>
+            {!tier.enabled && <span className="font-mono text-xs text-white/40">disabled</span>}
+            {canManage && (
+              <button
+                type="button"
+                className={buttonClass}
+                disabled={busy}
+                onClick={() =>
+                  act({ action: 'toggle-tier', percent: tier.percent, enabled: !tier.enabled })
+                }
+              >
+                {tier.enabled ? 'Disable' : 'Enable'}
+              </button>
+            )}
+          </div>
+        ))}
+        <div className={`${card} flex items-center gap-3`}>
+          <span className="font-mono text-xs text-white/50">Reward</span>
+          <span className="font-mono text-xs text-white/50">{rewardTagName}</span>
+          <span className="font-mono text-xs">{tagBadge(rewardTagName)}</span>
+        </div>
+      </div>
+      {canManage && (
+        <div className="flex flex-wrap items-center gap-2">
+          <input
+            className={`${inputClass} w-24`}
+            placeholder="%"
+            inputMode="numeric"
+            value={percent}
+            onChange={(e) => setPercent(e.target.value)}
+          />
+          <input
+            className={`${inputClass} w-48`}
+            placeholder="Momence tag (referral-20)"
+            value={tagName}
+            onChange={(e) => setTagName(e.target.value)}
+          />
+          <button
+            type="button"
+            className={buttonClass}
+            disabled={busy || !percent || !tagName}
+            onClick={async () => {
+              const ok = await act(
+                { action: 'create-tier', percent: Number(percent), tagName: tagName.trim() },
+                'Tier created — now create the tag + price rule in Momence'
+              );
+              if (ok) {
+                setPercent('');
+                setTagName('');
+              }
+            }}
+          >
+            Add tier
+          </button>
+          <button
+            type="button"
+            className={buttonClass}
+            disabled={busy}
+            onClick={() => act({ action: 'refresh-tag-cache' }, 'Momence tag cache refreshed')}
+          >
+            Refresh Momence tags
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function ReferrersSection({
+  referrers,
+  tiers,
+  canManage,
+  busy,
+  act,
+  search,
+  setSearch,
+  onSearch,
+}: {
+  referrers: ReferrerRow[];
+  tiers: ReferralTierRow[];
+  canManage: boolean;
+  busy: boolean;
+  act: Act;
+  search: string;
+  setSearch: (v: string) => void;
+  onSearch: () => void;
+}) {
+  const [memberEmail, setMemberEmail] = useState('');
+  const [partnerSlug, setPartnerSlug] = useState('');
+  const [partnerCode, setPartnerCode] = useState('');
+
+  return (
+    <section className="space-y-3">
+      <h2 className={sectionHeading}>Referrers</h2>
+
+      {canManage && (
+        <div className="flex flex-wrap items-center gap-2">
+          <input
+            className={`${inputClass} w-64`}
+            placeholder="Member email — mint their code"
+            value={memberEmail}
+            onChange={(e) => setMemberEmail(e.target.value)}
+          />
+          <button
+            type="button"
+            className={buttonClass}
+            disabled={busy || !memberEmail.trim()}
+            onClick={async () => {
+              const ok = await act(
+                { action: 'create-member-referrer', email: memberEmail.trim() },
+                'Member referrer ready'
+              );
+              if (ok) setMemberEmail('');
+            }}
+          >
+            Add member
+          </button>
+          <span className="text-white/20">|</span>
+          <input
+            className={`${inputClass} w-32`}
+            placeholder="partner slug"
+            value={partnerSlug}
+            onChange={(e) => setPartnerSlug(e.target.value)}
+          />
+          <input
+            className={`${inputClass} w-32`}
+            placeholder="CODE"
+            value={partnerCode}
+            onChange={(e) => setPartnerCode(e.target.value.toUpperCase())}
+          />
+          <button
+            type="button"
+            className={buttonClass}
+            disabled={busy || !partnerSlug.trim() || !partnerCode.trim()}
+            onClick={async () => {
+              const ok = await act(
+                {
+                  action: 'create-partner-referrer',
+                  partnerSlug: partnerSlug.trim(),
+                  code: partnerCode.trim(),
+                },
+                'Partner referrer created'
+              );
+              if (ok) {
+                setPartnerSlug('');
+                setPartnerCode('');
+              }
+            }}
+          >
+            Add partner
+          </button>
+        </div>
+      )}
+
+      <form
+        className="flex gap-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          onSearch();
+        }}
+      >
+        <input
+          className={`${inputClass} w-64`}
+          placeholder="Search code, name, email, slug"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <button type="submit" className={buttonClass} disabled={busy}>
+          Search
+        </button>
+      </form>
+
+      <div className="space-y-2">
+        {referrers.length === 0 && (
+          <p className="font-mono text-xs text-white/30">No referrers yet.</p>
+        )}
+        {referrers.map((referrer) => (
+          <div key={referrer.id} className={`${card} flex flex-wrap items-center gap-3`}>
+            <span className="font-mono text-sm font-bold text-[var(--pyre-creme)]">
+              {referrer.code}
+            </span>
+            <span className="text-sm text-white/70">{referrer.display_name}</span>
+            <span className="font-mono text-xs text-white/40">
+              {referrer.referrer_type === 'partner'
+                ? `partner:${referrer.partner_slug}`
+                : (referrer.email ?? `member:${referrer.momence_member_id}`)}
+            </span>
+            {canManage ? (
+              <select
+                className={`${inputClass} py-1`}
+                value={referrer.discount_percent}
+                disabled={busy}
+                onChange={(e) =>
+                  act({
+                    action: 'update-referrer',
+                    id: referrer.id,
+                    discountPercent: Number(e.target.value),
+                  })
+                }
+              >
+                {tiers.map((tier) => (
+                  <option key={tier.percent} value={tier.percent}>
+                    {tier.percent}%
+                  </option>
+                ))}
+              </select>
+            ) : (
+              <span className="font-mono text-xs text-white/50">{referrer.discount_percent}%</span>
+            )}
+            {!referrer.enabled && (
+              <span className="font-mono text-xs text-[var(--pyre-red)]">disabled</span>
+            )}
+            <span className="ml-auto font-mono text-xs text-white/30">
+              {fmtDate(referrer.created_at)}
+            </span>
+            {canManage && (
+              <button
+                type="button"
+                className={buttonClass}
+                disabled={busy}
+                onClick={() =>
+                  act({ action: 'update-referrer', id: referrer.id, enabled: !referrer.enabled })
+                }
+              >
+                {referrer.enabled ? 'Disable' : 'Enable'}
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function RedemptionsSection({
+  redemptions,
+  counts,
+  referrersById,
+  canManage,
+  busy,
+  act,
+  statusFilter,
+  setStatusFilter,
+}: {
+  redemptions: ReferralRedemptionRow[];
+  counts: Record<string, number>;
+  referrersById: Map<string, ReferrerRow>;
+  canManage: boolean;
+  busy: boolean;
+  act: Act;
+  statusFilter: string;
+  setStatusFilter: (v: string) => void;
+}) {
+  return (
+    <section className="space-y-3">
+      <h2 className={sectionHeading}>Redemptions</h2>
+      <div className="flex flex-wrap gap-2">
+        {REDEMPTION_FILTERS.map((status) => (
+          <button
+            key={status}
+            type="button"
+            className={pillClass(statusFilter === status)}
+            onClick={() => setStatusFilter(status)}
+          >
+            {status}
+            {status !== 'all' && counts[status] != null && ` (${counts[status]})`}
+          </button>
+        ))}
+      </div>
+      <div className="space-y-2">
+        {redemptions.length === 0 && (
+          <p className="font-mono text-xs text-white/30">Nothing here.</p>
+        )}
+        {redemptions.map((row) => {
+          const referrer = referrersById.get(row.referrer_id);
+          return (
+            <div key={row.id} className={`${card} flex flex-wrap items-center gap-3`}>
+              <span className={`font-mono text-xs uppercase ${STATUS_COLORS[row.status] ?? ''}`}>
+                {row.status}
+              </span>
+              <span className="text-sm text-white/80">
+                {row.friend_first_name} {row.friend_last_name}
+              </span>
+              <span className="font-mono text-xs text-white/40">{row.friend_email}</span>
+              <span className="font-mono text-xs text-white/50">
+                via {row.code}
+                {referrer ? ` (${referrer.display_name})` : ''} · {row.discount_percent}%
+              </span>
+              {row.cancelled_at && (
+                <span className="font-mono text-xs text-[var(--pyre-red)]">
+                  converting booking cancelled {fmtDate(row.cancelled_at)}
+                </span>
+              )}
+              {row.status === 'revoked' && row.revoke_reason && (
+                <span className="font-mono text-xs text-white/40">({row.revoke_reason})</span>
+              )}
+              <span className="ml-auto font-mono text-xs text-white/30">
+                {fmtDate(row.created_at)}
+                {row.converted_at && ` → booked ${fmtDate(row.converted_at)}`}
+              </span>
+              {canManage && (row.status === 'redeemed' || row.status === 'pending') && (
+                <button
+                  type="button"
+                  className={buttonClass}
+                  disabled={busy}
+                  onClick={() => {
+                    if (window.confirm(`Revoke ${row.friend_email}'s discount?`)) {
+                      act({ action: 'revoke-redemption', id: row.id }, 'Redemption revoked');
+                    }
+                  }}
+                >
+                  Revoke
+                </button>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function RewardsSection({
+  rewards,
+  referrersById,
+  canManage,
+  busy,
+  act,
+}: {
+  rewards: ReferralRewardRow[];
+  referrersById: Map<string, ReferrerRow>;
+  canManage: boolean;
+  busy: boolean;
+  act: Act;
+}) {
+  return (
+    <section className="space-y-3">
+      <h2 className={sectionHeading}>Rewards</h2>
+      <div className="space-y-2">
+        {rewards.length === 0 && (
+          <p className="font-mono text-xs text-white/30">No rewards granted yet.</p>
+        )}
+        {rewards.map((row) => {
+          const referrer = referrersById.get(row.referrer_id);
+          return (
+            <div key={row.id} className={`${card} flex flex-wrap items-center gap-3`}>
+              <span className={`font-mono text-xs uppercase ${STATUS_COLORS[row.status] ?? ''}`}>
+                {row.status}
+              </span>
+              <span className="text-sm text-white/80">
+                {referrer?.display_name ?? row.referrer_id}
+              </span>
+              {referrer && <span className="font-mono text-xs text-white/40">{referrer.code}</span>}
+              <span className="ml-auto font-mono text-xs text-white/30">
+                granted {fmtDate(row.granted_at)}
+                {row.consumed_at && ` → used ${fmtDate(row.consumed_at)}`}
+              </span>
+              {canManage && row.status === 'granted' && (
+                <button
+                  type="button"
+                  className={buttonClass}
+                  disabled={busy}
+                  onClick={() => {
+                    if (window.confirm('Revoke this reward?')) {
+                      act({ action: 'revoke-reward', id: row.id }, 'Reward revoked');
+                    }
+                  }}
+                >
+                  Revoke
+                </button>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/apps/integrations/src/components/admin/adminTools.ts
+++ b/apps/integrations/src/components/admin/adminTools.ts
@@ -68,6 +68,14 @@ export const ADMIN_TOOLS: AdminTool[] = [
     section: 'operations',
   },
   {
+    href: '/admin/referrals',
+    title: 'Referrals',
+    navLabel: 'Referrals',
+    description:
+      'Referrer codes for members and partners, the redemption queue, reward ledger, and discount tiers.',
+    section: 'marketing',
+  },
+  {
     href: '/admin/email',
     title: 'Email Performance',
     navLabel: 'Email',
@@ -122,10 +130,20 @@ export function hasPartnersManage(access: PageAccess): boolean {
   return access.isAdmin || access.pages.includes(PARTNERS_MANAGE);
 }
 
+// Same split for referrals: a plain '/admin/referrals' grant is read-only.
+// This key (or admin) unlocks creating/editing referrers and tiers and
+// revoking redemptions/rewards — all of which change Momence tags.
+export const REFERRALS_MANAGE = 'referrals:manage';
+
+export function hasReferralsManage(access: PageAccess): boolean {
+  return access.isAdmin || access.pages.includes(REFERRALS_MANAGE);
+}
+
 /** Manage capabilities that imply view access to the page they govern. */
 const MANAGE_IMPLIES_VIEW: Record<string, string> = {
   '/admin/schedule': SCHEDULE_MANAGE,
   '/admin/partners': PARTNERS_MANAGE,
+  '/admin/referrals': REFERRALS_MANAGE,
 };
 
 /** Whether this user may view the tool page at `href` (manage implies view). */

--- a/apps/integrations/src/emails/preview-props.ts
+++ b/apps/integrations/src/emails/preview-props.ts
@@ -13,6 +13,8 @@ import { PartnerDenied } from './templates/PartnerDenied';
 import { PartnerReconciliation } from './templates/PartnerReconciliation';
 import { PartnerVerificationRequest } from './templates/PartnerVerificationRequest';
 import { PartnerVerified } from './templates/PartnerVerified';
+import { ReferralRedeemed } from './templates/ReferralRedeemed';
+import { ReferralRewardEarned } from './templates/ReferralRewardEarned';
 import { ReviewRequest } from './templates/ReviewRequest';
 import { UnusedCreditReminder } from './templates/UnusedCreditReminder';
 import type { EmailPropsByTemplate } from './types';
@@ -30,4 +32,6 @@ export const EMAIL_PREVIEW_PROPS: { [K in keyof EmailPropsByTemplate]: EmailProp
   'partner-verified': PartnerVerified.PreviewProps,
   'partner-denied': PartnerDenied.PreviewProps,
   'partner-reconciliation': PartnerReconciliation.PreviewProps,
+  'referral-redeemed': ReferralRedeemed.PreviewProps,
+  'referral-reward-earned': ReferralRewardEarned.PreviewProps,
 };

--- a/apps/integrations/src/emails/registry.ts
+++ b/apps/integrations/src/emails/registry.ts
@@ -9,6 +9,8 @@ import { PartnerDenied } from './templates/PartnerDenied';
 import { PartnerReconciliation } from './templates/PartnerReconciliation';
 import { PartnerVerificationRequest } from './templates/PartnerVerificationRequest';
 import { PartnerVerified } from './templates/PartnerVerified';
+import { ReferralRedeemed } from './templates/ReferralRedeemed';
+import { ReferralRewardEarned } from './templates/ReferralRewardEarned';
 import { ReviewRequest } from './templates/ReviewRequest';
 import { UnusedCreditReminder } from './templates/UnusedCreditReminder';
 import type { EmailPropsByTemplate, EmailTemplateKey } from './types';
@@ -70,6 +72,14 @@ export const EMAIL_TEMPLATES: Registry = {
   'partner-reconciliation': {
     subject: (p) => `Quarterly member check - Pyre x ${p.partnerName}`,
     Component: PartnerReconciliation,
+  },
+  'referral-redeemed': {
+    subject: (p) => `${p.referrerName} gave you ${p.discountPercent}% off at Pyre`,
+    Component: ReferralRedeemed,
+  },
+  'referral-reward-earned': {
+    subject: (p) => `${p.friendFirstName} booked - your Pyre reward is live`,
+    Component: ReferralRewardEarned,
   },
 };
 

--- a/apps/integrations/src/emails/templates/ReferralRedeemed.tsx
+++ b/apps/integrations/src/emails/templates/ReferralRedeemed.tsx
@@ -1,0 +1,40 @@
+import { Button, Text } from '@react-email/components';
+import { button, EmailLayout, heading, text } from '../components/EmailLayout';
+import type { ReferralRedeemedProps } from '../types';
+
+// To the friend right after redeeming a referral code: the discount is already
+// live on their account - no code to enter at checkout.
+
+export function ReferralRedeemed({
+  firstName,
+  referrerName,
+  discountPercent,
+  bookUrl,
+}: ReferralRedeemedProps) {
+  return (
+    <EmailLayout preview={`Your ${discountPercent}% off first session at Pyre`} background="trees">
+      <Text style={heading}>Welcome, {firstName}</Text>
+      <Text style={text}>
+        {referrerName} sent you to us — your {discountPercent}% discount on your first session is
+        now live at Pyre.
+      </Text>
+      <Text style={text}>
+        Just sign up for a session with this email address and the discount comes off automatically
+        at checkout. No code needed.
+      </Text>
+      <Button href={bookUrl} style={button}>
+        Book your first session
+      </Button>
+      <Text style={text}>See you in the heat. Wes + Julien</Text>
+    </EmailLayout>
+  );
+}
+
+ReferralRedeemed.PreviewProps = {
+  firstName: 'Jane',
+  referrerName: 'Wes',
+  discountPercent: 15,
+  bookUrl: 'https://pyresauna.com/events?utm_source=referral&utm_medium=referral',
+} satisfies ReferralRedeemedProps;
+
+export default ReferralRedeemed;

--- a/apps/integrations/src/emails/templates/ReferralRewardEarned.tsx
+++ b/apps/integrations/src/emails/templates/ReferralRewardEarned.tsx
@@ -1,0 +1,37 @@
+import { Button, Text } from '@react-email/components';
+import { button, EmailLayout, heading, text } from '../components/EmailLayout';
+import type { ReferralRewardEarnedProps } from '../types';
+
+// To the referrer when a friend they referred completes their first booking:
+// their thank-you discount is live for their next session.
+
+export function ReferralRewardEarned({
+  firstName,
+  friendFirstName,
+  bookUrl,
+}: ReferralRewardEarnedProps) {
+  return (
+    <EmailLayout preview="Your referral reward at Pyre is live" background="trees">
+      <Text style={heading}>Nice one, {firstName}</Text>
+      <Text style={text}>
+        {friendFirstName} just booked their first session at Pyre — thanks to you. As a thank-you, a
+        discount on your next session is now live on your account.
+      </Text>
+      <Text style={text}>
+        Book with this email address and it comes off automatically at checkout. No code needed.
+      </Text>
+      <Button href={bookUrl} style={button}>
+        Book your next session
+      </Button>
+      <Text style={text}>Keep them coming. Wes + Julien</Text>
+    </EmailLayout>
+  );
+}
+
+ReferralRewardEarned.PreviewProps = {
+  firstName: 'Wes',
+  friendFirstName: 'Jane',
+  bookUrl: 'https://pyresauna.com/events?utm_source=referral-reward&utm_medium=referral',
+} satisfies ReferralRewardEarnedProps;
+
+export default ReferralRewardEarned;

--- a/apps/integrations/src/emails/types.ts
+++ b/apps/integrations/src/emails/types.ts
@@ -106,6 +106,22 @@ export interface PartnerReconciliationProps {
   members: { name: string; email: string }[];
 }
 
+// Referral program lifecycle (both transactional — no unsubscribeUrl).
+
+export interface ReferralRedeemedProps {
+  firstName: string;
+  /** The referrer as the friend knows them: "Wes" or "BFT Carytown". */
+  referrerName: string;
+  discountPercent: number;
+  bookUrl: string;
+}
+
+export interface ReferralRewardEarnedProps {
+  firstName: string;
+  friendFirstName: string;
+  bookUrl: string;
+}
+
 export interface EmailPropsByTemplate {
   confirmation: ConfirmationEmailProps;
   'first-timer-welcome': FirstTimerEmailProps;
@@ -119,6 +135,8 @@ export interface EmailPropsByTemplate {
   'partner-verified': PartnerVerifiedProps;
   'partner-denied': PartnerDeniedProps;
   'partner-reconciliation': PartnerReconciliationProps;
+  'referral-redeemed': ReferralRedeemedProps;
+  'referral-reward-earned': ReferralRewardEarnedProps;
 }
 
 export type EmailTemplateKey = keyof EmailPropsByTemplate;

--- a/apps/integrations/src/lib/cron/jobs.ts
+++ b/apps/integrations/src/lib/cron/jobs.ts
@@ -48,6 +48,13 @@ export const CRON_JOBS: CronJob[] = [
     run: async (ctx) => (await import('@/lib/partner/verification')).runPartnerMaintenance(ctx),
   },
   {
+    // Referral program upkeep: reconcile conversions the webhook missed,
+    // expire stale redemptions/rewards (removing their Momence tags), retry
+    // failed tag removals, clean crashed pending rows.
+    name: 'referral-maintenance',
+    run: async (ctx) => (await import('@/lib/referral/maintenance')).runReferralMaintenance(ctx),
+  },
+  {
     // Momence → shifts coverage-window sync for staff scheduling. Idempotent;
     // never touches sync_locked/staffed shifts beyond flagging them.
     name: 'sync-shifts',

--- a/apps/integrations/src/lib/db.ts
+++ b/apps/integrations/src/lib/db.ts
@@ -81,6 +81,73 @@ export interface PartnerVerificationRow {
   updated_at: string;
 }
 
+// A referral tier: which Momence tag (and therefore which manually-created
+// Price Rule) a given percent maps to. Managed from /admin/referrals.
+export interface ReferralTierRow {
+  percent: number;
+  tag_name: string;
+  enabled: boolean;
+  created_at: string;
+}
+
+// A referrer — an individual member or a partner business — and their
+// personalized code. Read through the cached registry in lib/referral/registry.ts.
+export interface ReferrerRow {
+  id: string;
+  referrer_type: 'member' | 'partner';
+  momence_member_id: number | null;
+  partner_slug: string | null;
+  email: string | null;
+  display_name: string;
+  code: string;
+  discount_percent: number;
+  enabled: boolean;
+  notes: string | null;
+  created_by: string | null;
+  updated_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ReferralRedemptionRow {
+  id: string;
+  referrer_id: string;
+  code: string;
+  discount_percent: number;
+  tag_name: string;
+  friend_first_name: string;
+  friend_last_name: string;
+  friend_email: string;
+  friend_momence_member_id: number | null;
+  status: 'pending' | 'redeemed' | 'converted' | 'expired' | 'revoked';
+  discount_tag_removed_at: string | null;
+  converted_session_id: number | null;
+  converted_session_booking_id: number | null;
+  converted_at: string | null;
+  cancelled_at: string | null;
+  revoked_at: string | null;
+  revoke_reason: string | null;
+  /** null = system, an email = admin action, 'cron' = maintenance sweep. */
+  decided_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ReferralRewardRow {
+  id: string;
+  referrer_id: string;
+  redemption_id: string;
+  reward_tag_name: string;
+  status: 'granted' | 'consumed' | 'expired' | 'revoked';
+  granted_at: string;
+  consumed_at: string | null;
+  consumed_session_booking_id: number | null;
+  reward_tag_removed_at: string | null;
+  decided_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
 // One chemical actually added to a tub with a water_tests entry. `grams` is
 // what went in the water; `recommended_grams` is what the dosing chart said,
 // so deviations stay auditable in the log.

--- a/apps/integrations/src/lib/momence/host-api.ts
+++ b/apps/integrations/src/lib/momence/host-api.ts
@@ -331,6 +331,10 @@ export async function assignMemberTag(memberId: number, tagId: number): Promise<
   await momenceRequest<void>('POST', `/host/members/${memberId}/tags/${tagId}`);
 }
 
+export async function removeMemberTag(memberId: number, tagId: number): Promise<void> {
+  await momenceRequest<void>('DELETE', `/host/members/${memberId}/tags/${tagId}`);
+}
+
 /**
  * Drop the cached name->id map. A tag created in the Momence dashboard is
  * otherwise invisible here for up to 24h, which makes every partner confirm

--- a/apps/integrations/src/lib/referral/admin-actions.ts
+++ b/apps/integrations/src/lib/referral/admin-actions.ts
@@ -1,0 +1,122 @@
+// Manual admin actions on the referral program: revoking a live discount or an
+// unconsumed reward. Both pull the Momence tag first (the actual discount)
+// and then flip the row with a conditional update, same ordering as the
+// automated paths.
+
+import { createWebhookLogger } from '@pyre/webhook-core';
+import { captureEvent } from '@/lib/analytics/posthog';
+import { getDb, type ReferralRedemptionRow, type ReferralRewardRow } from '@/lib/db';
+import { getTagIdByName, removeMemberTag } from '@/lib/momence/host-api';
+
+const log = createWebhookLogger('Referral Admin');
+
+export type RevokeResult =
+  | { outcome: 'revoked' }
+  | { outcome: 'not-found' }
+  | { outcome: 'not-revocable'; status: string };
+
+export async function revokeRedemption(
+  id: string,
+  actorEmail: string,
+  reason?: string
+): Promise<RevokeResult> {
+  const db = getDb();
+  if (!db) throw new Error('Supabase not configured');
+
+  const { data: row } = await db
+    .from('referral_redemptions')
+    .select('*')
+    .eq('id', id)
+    .maybeSingle<ReferralRedemptionRow>();
+  if (!row) return { outcome: 'not-found' };
+  // Only live discounts can be revoked; converted history stays converted.
+  if (row.status !== 'redeemed' && row.status !== 'pending') {
+    return { outcome: 'not-revocable', status: row.status };
+  }
+
+  let tagRemoved = false;
+  if (row.friend_momence_member_id) {
+    try {
+      const tagId = await getTagIdByName(row.tag_name);
+      if (tagId !== null) {
+        await removeMemberTag(row.friend_momence_member_id, tagId);
+        tagRemoved = true;
+      }
+    } catch (error) {
+      // Leave discount_tag_removed_at null — the maintenance sweep retries.
+      log.warn(`Revoke tag removal failed for redemption ${id}`, error);
+    }
+  }
+
+  const { data: updated } = await db
+    .from('referral_redemptions')
+    .update({
+      status: 'revoked',
+      revoked_at: new Date().toISOString(),
+      revoke_reason: reason?.trim() || 'admin',
+      decided_by: actorEmail,
+      ...(tagRemoved && { discount_tag_removed_at: new Date().toISOString() }),
+    })
+    .eq('id', id)
+    .in('status', ['redeemed', 'pending'])
+    .select('id');
+  if (!updated || updated.length === 0) return { outcome: 'not-revocable', status: row.status };
+
+  await captureEvent({
+    distinctId: row.friend_email,
+    event: 'referral_revoked',
+    properties: { code: row.code, reason: reason?.trim() || 'admin' },
+  });
+  return { outcome: 'revoked' };
+}
+
+export async function revokeReward(id: string, actorEmail: string): Promise<RevokeResult> {
+  const db = getDb();
+  if (!db) throw new Error('Supabase not configured');
+
+  const { data: row } = await db
+    .from('referral_rewards')
+    .select('*')
+    .eq('id', id)
+    .maybeSingle<ReferralRewardRow>();
+  if (!row) return { outcome: 'not-found' };
+  if (row.status !== 'granted') return { outcome: 'not-revocable', status: row.status };
+
+  const { data: referrer } = await db
+    .from('referrers')
+    .select('momence_member_id, email, code')
+    .eq('id', row.referrer_id)
+    .maybeSingle<{ momence_member_id: number | null; email: string | null; code: string }>();
+
+  let tagRemoved = false;
+  if (referrer?.momence_member_id) {
+    try {
+      const tagId = await getTagIdByName(row.reward_tag_name);
+      if (tagId !== null) {
+        await removeMemberTag(referrer.momence_member_id, tagId);
+        tagRemoved = true;
+      }
+    } catch (error) {
+      log.warn(`Revoke tag removal failed for reward ${id}`, error);
+    }
+  }
+
+  const { data: updated } = await db
+    .from('referral_rewards')
+    .update({
+      status: 'revoked',
+      decided_by: actorEmail,
+      ...(tagRemoved && { reward_tag_removed_at: new Date().toISOString() }),
+    })
+    .eq('id', id)
+    .eq('status', 'granted')
+    .select('id');
+  if (!updated || updated.length === 0) return { outcome: 'not-revocable', status: row.status };
+
+  await captureEvent({
+    distinctId: referrer?.email ?? referrer?.code ?? row.referrer_id,
+    event: 'referral_reward_revoked',
+    properties: { code: referrer?.code },
+  });
+  return { outcome: 'revoked' };
+}

--- a/apps/integrations/src/lib/referral/api-auth.ts
+++ b/apps/integrations/src/lib/referral/api-auth.ts
@@ -1,0 +1,14 @@
+// Shared-secret auth for the landing-page -> integrations referral relay.
+// Its own secret (not PARTNER_API_SECRET) so the two programs can rotate keys
+// independently.
+
+export function isReferralAuthorized(request: Request): boolean {
+  // process.env fallback: import.meta.env inlines at build time; vars added
+  // after the cached build only exist at runtime.
+  const secret = import.meta.env.REFERRAL_API_SECRET ?? process.env.REFERRAL_API_SECRET;
+  if (!secret) {
+    console.error('[Referral] REFERRAL_API_SECRET not configured — rejecting all requests');
+    return false;
+  }
+  return request.headers.get('Authorization') === `Bearer ${secret}`;
+}

--- a/apps/integrations/src/lib/referral/codes.ts
+++ b/apps/integrations/src/lib/referral/codes.ts
@@ -1,0 +1,81 @@
+// Referral code generation + click counting. Codes are human-speakable
+// ("use WES15") rather than opaque shortlink slugs, because the /r/{code}
+// landing page renders the referrer's name server-side and the code doubles as
+// something a customer can say out loud at the front desk.
+
+import { getRedis } from '@pyre/webhook-core';
+
+const CODE_PATTERN = /^[A-Z0-9]{3,16}$/;
+
+/** Uppercase letters only, from whatever the first name contains. */
+function namePart(firstName: string): string {
+  const letters = firstName
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '') // strip diacritics so "José" -> "JOSE"
+    .replace(/[^a-zA-Z]/g, '')
+    .toUpperCase()
+    .slice(0, 10);
+  // A name with no usable letters still needs a base ("李" or emoji names).
+  return letters || 'PYRE';
+}
+
+function randomDigits(count: number): string {
+  let out = '';
+  for (let i = 0; i < count; i += 1) out += Math.floor(Math.random() * 10);
+  return out;
+}
+
+/**
+ * Candidate codes for a first name: FIRSTNAME + 2 digits, widening to 3 digits
+ * after repeated collisions, then a fully random suffix as the last resort.
+ * The caller owns collision detection (the unique index on referrers.code) and
+ * walks this sequence until an insert sticks.
+ */
+export function codeCandidates(firstName: string, attempts = 8): string[] {
+  const base = namePart(firstName);
+  const candidates: string[] = [];
+  for (let i = 0; i < attempts; i += 1) {
+    const digits = i < 3 ? randomDigits(2) : randomDigits(3);
+    candidates.push(`${base}${digits}`.slice(0, 16));
+  }
+  // Last resort keeps the name prefix short so the random tail dominates.
+  candidates.push(`${base.slice(0, 6)}${Math.random().toString(36).slice(2, 8).toUpperCase()}`);
+  return candidates.filter((c) => CODE_PATTERN.test(c));
+}
+
+export function isValidCode(code: string): boolean {
+  return CODE_PATTERN.test(code);
+}
+
+export function normalizeCode(code: string): string {
+  return code.trim().toUpperCase();
+}
+
+// --- Click counting ---
+//
+// Redis counter so /account stats don't need a PostHog query. PostHog gets a
+// referral_link_clicked event separately (client-side on the /r page) for
+// funnel analysis; this counter is the cheap always-available number.
+
+const CLICKS_PREFIX = 'referral:clicks:';
+
+export async function incrementReferralClicks(code: string): Promise<void> {
+  const redis = getRedis();
+  if (!redis) return;
+  try {
+    await redis.incr(`${CLICKS_PREFIX}${normalizeCode(code)}`);
+  } catch {
+    // A lost click count must never break the landing page.
+  }
+}
+
+export async function getReferralClicks(code: string): Promise<number> {
+  const redis = getRedis();
+  if (!redis) return 0;
+  try {
+    const value = await redis.get<number>(`${CLICKS_PREFIX}${normalizeCode(code)}`);
+    return value ?? 0;
+  } catch {
+    return 0;
+  }
+}

--- a/apps/integrations/src/lib/referral/conversion.ts
+++ b/apps/integrations/src/lib/referral/conversion.ts
@@ -1,0 +1,360 @@
+// Conversion + reward side of the referral program, driven by the
+// session-booked webhook (and re-driven by the maintenance sweep for missed
+// webhooks). Best-effort by contract: every entry point catches its own
+// errors — a referral hiccup must never 500 the webhook and trigger Momence
+// retries.
+
+import { createWebhookLogger } from '@pyre/webhook-core';
+import { captureEvent } from '@/lib/analytics/posthog';
+import { getDb, type ReferralRedemptionRow, type ReferrerRow } from '@/lib/db';
+import { sendTemplate } from '@/lib/email/send';
+import { assignMemberTag, getTagIdByName, removeMemberTag } from '@/lib/momence/host-api';
+import { isMemberFirstBooking } from '@/lib/webhooks/momence';
+import { getReferrer, getReferrerByMemberId, getRewardTagName } from './registry';
+
+const log = createWebhookLogger('Referral Conversion');
+
+const TABLE = 'referral_redemptions';
+
+/**
+ * The conversion-granting booking must not also consume the reward it just
+ * granted when webhooks arrive out of order — a reward is only consumable
+ * this long after it was granted.
+ */
+const REWARD_GRACE_MS = 5 * 60 * 1000;
+
+function rewardBookUrl(): string {
+  const site =
+    import.meta.env.PUBLIC_SITE_URL ?? process.env.PUBLIC_SITE_URL ?? 'https://pyresauna.com';
+  return `${site}/events?utm_source=referral-reward&utm_medium=referral&utm_campaign=referral-reward`;
+}
+
+/** Remove the redemption's tier tag from the tagged member. True on success. */
+async function removeDiscountTag(redemption: ReferralRedemptionRow): Promise<boolean> {
+  if (!redemption.friend_momence_member_id) return false;
+  try {
+    const tagId = await getTagIdByName(redemption.tag_name);
+    if (tagId === null) {
+      log.warn(`Tier tag "${redemption.tag_name}" not found while removing — skipping`);
+      return false;
+    }
+    await removeMemberTag(redemption.friend_momence_member_id, tagId);
+    return true;
+  } catch (error) {
+    log.warn(`Tier tag removal failed for member ${redemption.friend_momence_member_id}`, error);
+    return false;
+  }
+}
+
+/**
+ * Grant the referrer their reward: ledger row (the idempotency claim), reward
+ * tag, email. Member referrers only — partner conversions are settled
+ * manually off the redemption counts.
+ */
+async function grantReward(
+  redemption: ReferralRedemptionRow,
+  referrer: ReferrerRow,
+  friendFirstName: string
+): Promise<void> {
+  const db = getDb();
+  if (!db) return;
+  if (referrer.referrer_type !== 'member' || !referrer.momence_member_id || !referrer.email) {
+    return;
+  }
+
+  const rewardTagName = getRewardTagName();
+
+  // The unique redemption_id claim makes webhook retries no-ops. Claim before
+  // the Momence write: a duplicate insert means another invocation owns this
+  // reward, tag and email included.
+  const { error } = await db.from('referral_rewards').insert({
+    referrer_id: referrer.id,
+    redemption_id: redemption.id,
+    reward_tag_name: rewardTagName,
+  });
+  if (error) {
+    if (error.code !== '23505') log.error('Reward insert failed', error);
+    return;
+  }
+
+  try {
+    const tagId = await getTagIdByName(rewardTagName);
+    if (tagId === null) {
+      log.error(`Reward tag "${rewardTagName}" not found — create it in the dashboard first`);
+    } else {
+      await assignMemberTag(referrer.momence_member_id, tagId);
+    }
+  } catch (tagError) {
+    // The ledger row exists either way; the admin queue surfaces grant rows
+    // whose tag never landed via the Momence member view.
+    log.error(`Reward tag assignment failed for referrer ${referrer.id}`, tagError);
+  }
+
+  try {
+    await sendTemplate({
+      to: referrer.email,
+      template: 'referral-reward-earned',
+      props: {
+        firstName: referrer.display_name,
+        friendFirstName,
+        bookUrl: rewardBookUrl(),
+      },
+      sendKey: `referral-reward:${redemption.id}`,
+    });
+  } catch (emailError) {
+    log.warn(`Reward email failed for ${referrer.email}`, emailError);
+  }
+
+  await captureEvent({
+    distinctId: referrer.email,
+    event: 'referral_reward_granted',
+    properties: { code: redemption.code, redemption_id: redemption.id },
+  });
+}
+
+export interface ConversionBooking {
+  sessionId: number | null;
+  sessionBookingId: number | null;
+}
+
+/**
+ * Convert a `redeemed` row: remove the friend's discount tag, grant the
+ * referrer's reward, flip the status. The caller has already decided this
+ * booking qualifies (first-booking gate in the webhook path; "was booking-free
+ * at redemption and has a booking now" in the reconciliation path).
+ */
+export async function convertRedemption(
+  redemption: ReferralRedemptionRow,
+  booking: ConversionBooking
+): Promise<void> {
+  const db = getDb();
+  if (!db) return;
+
+  // Momence work before the status flip (house rule). A failed removal still
+  // converts — the maintenance sweep retries rows whose tag never came off.
+  const tagRemoved = await removeDiscountTag(redemption);
+
+  const { data: updated } = await db
+    .from(TABLE)
+    .update({
+      status: 'converted',
+      converted_session_id: booking.sessionId,
+      converted_session_booking_id: booking.sessionBookingId,
+      converted_at: new Date().toISOString(),
+      ...(tagRemoved && { discount_tag_removed_at: new Date().toISOString() }),
+    })
+    .eq('id', redemption.id)
+    .eq('status', 'redeemed')
+    .select('id');
+  // Lost a race with another webhook delivery — the winner owns the reward.
+  if (!updated || updated.length === 0) return;
+
+  const referrer = await getReferrer(redemption.referrer_id);
+  if (referrer) {
+    await grantReward(redemption, referrer, redemption.friend_first_name);
+  }
+
+  await captureEvent({
+    distinctId: redemption.friend_email,
+    event: 'referral_converted',
+    properties: {
+      code: redemption.code,
+      discount_percent: redemption.discount_percent,
+      session_id: booking.sessionId,
+    },
+  });
+}
+
+/**
+ * The first-booking re-check failed at conversion time: the "friend" had
+ * prior bookings after all (booked under this account before redeeming, or
+ * accounts merged). Pull the tag, void the redemption, grant nothing.
+ */
+async function revokeNotFirstTime(redemption: ReferralRedemptionRow): Promise<void> {
+  const db = getDb();
+  if (!db) return;
+
+  const tagRemoved = await removeDiscountTag(redemption);
+
+  const { data: updated } = await db
+    .from(TABLE)
+    .update({
+      status: 'revoked',
+      revoked_at: new Date().toISOString(),
+      revoke_reason: 'not-first-time',
+      ...(tagRemoved && { discount_tag_removed_at: new Date().toISOString() }),
+    })
+    .eq('id', redemption.id)
+    .eq('status', 'redeemed')
+    .select('id');
+  if (!updated || updated.length === 0) return;
+
+  log.warn(
+    `Redemption ${redemption.id} revoked: ${redemption.friend_email} had prior bookings at conversion time`
+  );
+  await captureEvent({
+    distinctId: redemption.friend_email,
+    event: 'referral_rejected_not_first_time',
+    properties: { code: redemption.code },
+  });
+}
+
+/**
+ * The referrer's next booking after a reward grant consumes the reward:
+ * remove the reward tag, mark the ledger row. Known v1 approximation — the
+ * booking may not have actually used the discount (credit/membership
+ * bookings); sales-price inspection is the v2 upgrade.
+ */
+async function consumeRewardIfDue(memberId: number, sessionBookingId: number): Promise<void> {
+  const db = getDb();
+  if (!db) return;
+
+  const referrer = await getReferrerByMemberId(memberId);
+  if (!referrer) return;
+
+  const cutoff = new Date(Date.now() - REWARD_GRACE_MS).toISOString();
+  const { data } = await db
+    .from('referral_rewards')
+    .select('*')
+    .eq('referrer_id', referrer.id)
+    .eq('status', 'granted')
+    .lt('granted_at', cutoff)
+    .order('granted_at', { ascending: true })
+    .limit(1);
+  const reward = data?.[0];
+  if (!reward) return;
+
+  let tagRemoved = false;
+  try {
+    const tagId = await getTagIdByName(reward.reward_tag_name);
+    if (tagId !== null && referrer.momence_member_id) {
+      await removeMemberTag(referrer.momence_member_id, tagId);
+      tagRemoved = true;
+    }
+  } catch (error) {
+    log.warn(`Reward tag removal failed for referrer ${referrer.id}`, error);
+  }
+
+  const { data: updated } = await db
+    .from('referral_rewards')
+    .update({
+      status: 'consumed',
+      consumed_at: new Date().toISOString(),
+      consumed_session_booking_id: sessionBookingId,
+      ...(tagRemoved && { reward_tag_removed_at: new Date().toISOString() }),
+    })
+    .eq('id', reward.id)
+    .eq('status', 'granted')
+    .select('id');
+  if (!updated || updated.length === 0) return;
+
+  await captureEvent({
+    distinctId: referrer.email ?? referrer.code,
+    event: 'referral_reward_consumed',
+    properties: { code: referrer.code, session_booking_id: sessionBookingId },
+  });
+}
+
+/**
+ * session-booked hook. Two independent questions about the person who just
+ * booked: are they a referred friend awaiting their first booking (convert +
+ * reward the referrer), and are they a referrer holding an unconsumed reward
+ * (consume it)?
+ */
+export async function handleReferralBooking(params: {
+  sessionId: number;
+  sessionBookingId: number;
+  targetMemberId: number;
+  memberEmail: string;
+}): Promise<void> {
+  const db = getDb();
+  if (!db) return;
+
+  try {
+    let { data } = await db
+      .from(TABLE)
+      .select('*')
+      .eq('friend_momence_member_id', params.targetMemberId)
+      .eq('status', 'redeemed')
+      .limit(1);
+    let redemption = (data?.[0] ?? null) as ReferralRedemptionRow | null;
+
+    // Fallback: the friend booked under a different Momence record than the
+    // one we tagged (email lookup at booking created a second account). The
+    // discount didn't apply, but the referral is real — convert it anyway so
+    // the referrer isn't cheated, and log it as its own case.
+    if (!redemption && params.memberEmail) {
+      ({ data } = await db
+        .from(TABLE)
+        .select('*')
+        .eq('friend_email', params.memberEmail.trim().toLowerCase())
+        .eq('status', 'redeemed')
+        .limit(1));
+      redemption = (data?.[0] ?? null) as ReferralRedemptionRow | null;
+      if (redemption) {
+        log.warn(
+          `Redemption ${redemption.id} matched by email, not member id — friend booked under member ${params.targetMemberId}, tagged member is ${redemption.friend_momence_member_id}`
+        );
+      }
+    }
+
+    if (redemption) {
+      // Hard first-time gate, re-checked at conversion. false = prior bookings
+      // surfaced since redemption -> revoke, no reward. null = can't tell ->
+      // leave the row for the reconciliation sweep to retry.
+      const firstBooking = await isMemberFirstBooking(
+        String(params.targetMemberId),
+        params.sessionBookingId
+      );
+      if (firstBooking === false) {
+        await revokeNotFirstTime(redemption);
+      } else if (firstBooking === true) {
+        await convertRedemption(redemption, {
+          sessionId: params.sessionId,
+          sessionBookingId: params.sessionBookingId,
+        });
+      } else {
+        log.warn(`First-booking check inconclusive for redemption ${redemption.id} — deferring`);
+      }
+    }
+  } catch (error) {
+    log.error('Referral conversion handling failed', error);
+  }
+
+  try {
+    await consumeRewardIfDue(params.targetMemberId, params.sessionBookingId);
+  } catch (error) {
+    log.error('Reward consumption handling failed', error);
+  }
+}
+
+/**
+ * session-booking-cancelled hook: flag a converted redemption whose
+ * converting booking was cancelled. Admin decides whether to revoke the
+ * reward — no automatic clawback (the reward email already went out).
+ */
+export async function handleReferralCancellation(sessionBookingId: number): Promise<void> {
+  const db = getDb();
+  if (!db) return;
+
+  try {
+    const { data } = await db
+      .from(TABLE)
+      .update({ cancelled_at: new Date().toISOString() })
+      .eq('converted_session_booking_id', sessionBookingId)
+      .eq('status', 'converted')
+      .is('cancelled_at', null)
+      .select('id, friend_email, code');
+    const row = data?.[0];
+    if (row) {
+      log.warn(`Converting booking ${sessionBookingId} cancelled — redemption ${row.id} flagged`);
+      await captureEvent({
+        distinctId: row.friend_email,
+        event: 'referral_conversion_cancelled',
+        properties: { code: row.code, session_booking_id: sessionBookingId },
+      });
+    }
+  } catch (error) {
+    log.error('Referral cancellation handling failed', error);
+  }
+}

--- a/apps/integrations/src/lib/referral/maintenance.ts
+++ b/apps/integrations/src/lib/referral/maintenance.ts
@@ -1,0 +1,280 @@
+// Hourly upkeep for the referral program, run from the cron tick:
+//   - reconcile: convert `redeemed` rows whose friend booked but whose
+//     webhook we missed (or whose first-booking check was inconclusive)
+//   - expire: redemptions unbooked past the window, rewards unused past 90d
+//   - retag cleanup: converted rows whose discount tag never came off
+//   - stale pending: rows that crashed between insert and the Momence write
+//
+// Everything is idempotent: status flips are conditional updates, tag
+// removals are safe to repeat, and dryRun reports without writing.
+
+import { createWebhookLogger } from '@pyre/webhook-core';
+import { captureEvent } from '@/lib/analytics/posthog';
+import type { CronJobContext } from '@/lib/cron/jobs';
+import { getDb, type ReferralRedemptionRow, type ReferralRewardRow } from '@/lib/db';
+import { getTagIdByName, removeMemberTag } from '@/lib/momence/host-api';
+import { memberHasBookings } from '@/lib/webhooks/momence';
+import { convertRedemption } from './conversion';
+import { getRedemptionExpiryDays, REWARD_EXPIRY_DAYS } from './registry';
+
+const log = createWebhookLogger('Referral Maintenance');
+
+const TABLE = 'referral_redemptions';
+const BATCH = 25;
+
+/** Give the webhook a clear head start before the sweep second-guesses it. */
+const RECONCILE_MIN_AGE_MS = 2 * 60 * 60 * 1000;
+const STALE_PENDING_MS = 60 * 60 * 1000;
+
+async function removeTagFromMember(memberId: number | null, tagName: string): Promise<boolean> {
+  if (!memberId) return false;
+  try {
+    const tagId = await getTagIdByName(tagName);
+    if (tagId === null) return false;
+    await removeMemberTag(memberId, tagId);
+    return true;
+  } catch (error) {
+    log.warn(`Tag removal failed for member ${memberId} / ${tagName}`, error);
+    return false;
+  }
+}
+
+/**
+ * Missed-webhook reconciliation. Eligibility guaranteed zero bookings at
+ * redemption time, so any booking now IS the first — convert without
+ * re-gating.
+ */
+async function reconcileRedeemed(
+  ctx: CronJobContext
+): Promise<{ converted: number; wouldConvert: string[] }> {
+  const db = getDb();
+  if (!db) return { converted: 0, wouldConvert: [] };
+
+  const cutoff = new Date(Date.now() - RECONCILE_MIN_AGE_MS).toISOString();
+  const { data } = await db
+    .from(TABLE)
+    .select('*')
+    .eq('status', 'redeemed')
+    .lt('created_at', cutoff)
+    .order('created_at', { ascending: true })
+    .limit(BATCH);
+  const rows = (data ?? []) as ReferralRedemptionRow[];
+
+  let converted = 0;
+  const wouldConvert: string[] = [];
+  for (const row of rows) {
+    if (ctx.timeRemainingMs() < 10_000) break;
+    if (!row.friend_momence_member_id) continue;
+
+    const hasBookings = await memberHasBookings(String(row.friend_momence_member_id));
+    if (hasBookings !== true) continue;
+
+    if (ctx.dryRun) {
+      wouldConvert.push(`${row.code}:${row.friend_email}`);
+      continue;
+    }
+    // Session ids unknown here — the row records the conversion, not the
+    // specific booking. Cancellation flagging only works for webhook-observed
+    // conversions, which is fine.
+    await convertRedemption(row, { sessionId: null, sessionBookingId: null });
+    converted += 1;
+  }
+
+  return { converted, wouldConvert };
+}
+
+async function expireRedemptions(
+  ctx: CronJobContext
+): Promise<{ expired: number; wouldExpire: string[] }> {
+  const db = getDb();
+  if (!db) return { expired: 0, wouldExpire: [] };
+
+  const cutoff = new Date(
+    Date.now() - getRedemptionExpiryDays() * 24 * 60 * 60 * 1000
+  ).toISOString();
+  const { data } = await db
+    .from(TABLE)
+    .select('*')
+    .eq('status', 'redeemed')
+    .lt('created_at', cutoff)
+    .order('created_at', { ascending: true })
+    .limit(BATCH);
+  const rows = (data ?? []) as ReferralRedemptionRow[];
+
+  if (ctx.dryRun) {
+    return { expired: 0, wouldExpire: rows.map((r) => `${r.code}:${r.friend_email}`) };
+  }
+
+  let expired = 0;
+  for (const row of rows) {
+    if (ctx.timeRemainingMs() < 10_000) break;
+    const tagRemoved = await removeTagFromMember(row.friend_momence_member_id, row.tag_name);
+    const { data: updated } = await db
+      .from(TABLE)
+      .update({
+        status: 'expired',
+        decided_by: 'cron',
+        ...(tagRemoved && { discount_tag_removed_at: new Date().toISOString() }),
+      })
+      .eq('id', row.id)
+      .eq('status', 'redeemed')
+      .select('id');
+    if (!updated || updated.length === 0) continue;
+    expired += 1;
+    await captureEvent({
+      distinctId: row.friend_email,
+      event: 'referral_expired',
+      properties: { code: row.code },
+    });
+  }
+
+  return { expired, wouldExpire: [] };
+}
+
+async function expireRewards(
+  ctx: CronJobContext
+): Promise<{ expired: number; wouldExpire: string[] }> {
+  const db = getDb();
+  if (!db) return { expired: 0, wouldExpire: [] };
+
+  const cutoff = new Date(Date.now() - REWARD_EXPIRY_DAYS * 24 * 60 * 60 * 1000).toISOString();
+  const { data } = await db
+    .from('referral_rewards')
+    .select('*')
+    .eq('status', 'granted')
+    .lt('granted_at', cutoff)
+    .order('granted_at', { ascending: true })
+    .limit(BATCH);
+  const rows = (data ?? []) as ReferralRewardRow[];
+
+  if (ctx.dryRun) {
+    return { expired: 0, wouldExpire: rows.map((r) => r.id) };
+  }
+
+  let expired = 0;
+  for (const row of rows) {
+    if (ctx.timeRemainingMs() < 10_000) break;
+    const { data: referrerRows } = await db
+      .from('referrers')
+      .select('momence_member_id, email, code')
+      .eq('id', row.referrer_id)
+      .maybeSingle<{ momence_member_id: number | null; email: string | null; code: string }>();
+    const tagRemoved = await removeTagFromMember(
+      referrerRows?.momence_member_id ?? null,
+      row.reward_tag_name
+    );
+    const { data: updated } = await db
+      .from('referral_rewards')
+      .update({
+        status: 'expired',
+        decided_by: 'cron',
+        ...(tagRemoved && { reward_tag_removed_at: new Date().toISOString() }),
+      })
+      .eq('id', row.id)
+      .eq('status', 'granted')
+      .select('id');
+    if (!updated || updated.length === 0) continue;
+    expired += 1;
+    await captureEvent({
+      distinctId: referrerRows?.email ?? referrerRows?.code ?? row.referrer_id,
+      event: 'referral_reward_expired',
+      properties: { code: referrerRows?.code },
+    });
+  }
+
+  return { expired, wouldExpire: [] };
+}
+
+/** Converted/expired/revoked rows whose discount tag never actually came off. */
+async function retryDanglingTagRemovals(ctx: CronJobContext): Promise<{ removed: number }> {
+  const db = getDb();
+  if (!db) return { removed: 0 };
+
+  const { data } = await db
+    .from(TABLE)
+    .select('*')
+    .in('status', ['converted', 'expired', 'revoked'])
+    .is('discount_tag_removed_at', null)
+    .not('friend_momence_member_id', 'is', null)
+    .order('updated_at', { ascending: true })
+    .limit(BATCH);
+  const rows = (data ?? []) as ReferralRedemptionRow[];
+
+  let removed = 0;
+  for (const row of rows) {
+    if (ctx.timeRemainingMs() < 10_000) break;
+    if (ctx.dryRun) continue;
+    const tagRemoved = await removeTagFromMember(row.friend_momence_member_id, row.tag_name);
+    if (!tagRemoved) continue;
+    await db
+      .from(TABLE)
+      .update({ discount_tag_removed_at: new Date().toISOString() })
+      .eq('id', row.id);
+    removed += 1;
+  }
+
+  return { removed };
+}
+
+/**
+ * Rows that crashed between insert and the redeemed flip. The Momence tag may
+ * or may not have landed, so attempt removal, then expire (not delete — the
+ * audit trail keeps no-deletes) and free the friend_email for a clean retry.
+ */
+async function expireStalePending(ctx: CronJobContext): Promise<{ cleaned: number }> {
+  const db = getDb();
+  if (!db) return { cleaned: 0 };
+
+  const cutoff = new Date(Date.now() - STALE_PENDING_MS).toISOString();
+  const { data } = await db
+    .from(TABLE)
+    .select('*')
+    .eq('status', 'pending')
+    .lt('created_at', cutoff)
+    .limit(BATCH);
+  const rows = (data ?? []) as ReferralRedemptionRow[];
+
+  let cleaned = 0;
+  for (const row of rows) {
+    if (ctx.timeRemainingMs() < 10_000) break;
+    if (ctx.dryRun) continue;
+    const tagRemoved = await removeTagFromMember(row.friend_momence_member_id, row.tag_name);
+    const { data: updated } = await db
+      .from(TABLE)
+      .update({
+        status: 'expired',
+        decided_by: 'cron',
+        revoke_reason: 'stale-pending',
+        ...(tagRemoved && { discount_tag_removed_at: new Date().toISOString() }),
+      })
+      .eq('id', row.id)
+      .eq('status', 'pending')
+      .select('id');
+    if (updated && updated.length > 0) cleaned += 1;
+  }
+
+  return { cleaned };
+}
+
+export async function runReferralMaintenance(
+  ctx: CronJobContext
+): Promise<Record<string, unknown>> {
+  const reconcile = await reconcileRedeemed(ctx);
+  const redemptionExpiry = await expireRedemptions(ctx);
+  const rewardExpiry = await expireRewards(ctx);
+  const dangling = await retryDanglingTagRemovals(ctx);
+  const stalePending = await expireStalePending(ctx);
+
+  return {
+    reconciledConversions: reconcile.converted,
+    redemptionsExpired: redemptionExpiry.expired,
+    rewardsExpired: rewardExpiry.expired,
+    danglingTagsRemoved: dangling.removed,
+    stalePendingCleaned: stalePending.cleaned,
+    ...(ctx.dryRun && {
+      wouldConvert: reconcile.wouldConvert,
+      wouldExpireRedemptions: redemptionExpiry.wouldExpire,
+      wouldExpireRewards: rewardExpiry.wouldExpire,
+    }),
+  };
+}

--- a/apps/integrations/src/lib/referral/redemption.ts
+++ b/apps/integrations/src/lib/referral/redemption.ts
@@ -1,0 +1,188 @@
+// The friend-side redemption path: code -> eligibility checks -> Momence
+// member find-or-create + tier tag -> `redeemed` row -> confirmation email.
+// Synchronous (no approval step, unlike partner verification) because the
+// referrer already vouched by sharing their code.
+//
+// Hard rule enforced here and re-checked at conversion: first-time customers
+// only. Anyone with session booking history — attended, upcoming, or
+// cancelled — is rejected.
+
+import { createWebhookLogger } from '@pyre/webhook-core';
+import { captureEvent } from '@/lib/analytics/posthog';
+import { getDb, type ReferralRedemptionRow } from '@/lib/db';
+import { sendTemplate } from '@/lib/email/send';
+import {
+  assignMemberTag,
+  createMember,
+  findMemberByEmail,
+  getTagIdByName,
+} from '@/lib/momence/host-api';
+import { memberHasBookings } from '@/lib/webhooks/momence';
+import { getTier, lookupReferrerByCode } from './registry';
+
+const log = createWebhookLogger('Referral Redemption');
+
+const TABLE = 'referral_redemptions';
+
+export type RedeemResult =
+  | { outcome: 'redeemed' }
+  | { outcome: 'already-redeemed'; status: ReferralRedemptionRow['status'] }
+  | {
+      outcome: 'rejected';
+      reason: 'unknown-code' | 'referrer-disabled' | 'self-referral' | 'existing-customer';
+    }
+  | { outcome: 'unavailable'; reason: string };
+
+function bookUrl(code: string): string {
+  const site =
+    import.meta.env.PUBLIC_SITE_URL ?? process.env.PUBLIC_SITE_URL ?? 'https://pyresauna.com';
+  // utm_campaign carries the code so the existing campaign-performance report
+  // and booking_link_clicked attribution pick referred bookings up unchanged.
+  return `${site}/events?utm_source=referral&utm_medium=referral&utm_campaign=${code.toLowerCase()}`;
+}
+
+export async function redeemReferral(params: {
+  code: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+}): Promise<RedeemResult> {
+  const db = getDb();
+  if (!db) return { outcome: 'unavailable', reason: 'db-not-configured' };
+
+  const lookup = await lookupReferrerByCode(params.code);
+  if (lookup.status === 'unavailable') {
+    return { outcome: 'unavailable', reason: 'storage-unavailable' };
+  }
+  if (lookup.status === 'unknown') return { outcome: 'rejected', reason: 'unknown-code' };
+  if (lookup.status === 'disabled') return { outcome: 'rejected', reason: 'referrer-disabled' };
+  const referrer = lookup.referrer;
+
+  const friendEmail = params.email.trim().toLowerCase();
+
+  if (referrer.email && referrer.email === friendEmail) {
+    return { outcome: 'rejected', reason: 'self-referral' };
+  }
+
+  // One referral discount per friend, ever, across all referrers. Checked
+  // up front for a friendly response; the partial unique index is the real
+  // guard against races.
+  const { data: existing } = await db
+    .from(TABLE)
+    .select('id, status')
+    .eq('friend_email', friendEmail)
+    .in('status', ['pending', 'redeemed', 'converted'])
+    .limit(1);
+  if (existing && existing.length > 0) {
+    return { outcome: 'already-redeemed', status: existing[0].status };
+  }
+
+  // First-time-only. A Momence record alone is fine (newsletter signups and
+  // partner verifications create memberless-in-spirit rows) — booking history
+  // is what disqualifies. The visits counter comes free with the member; the
+  // sessions endpoint is the authoritative check behind it. When the sessions
+  // check can't answer, the visits counter decides alone.
+  const member = await findMemberByEmail(friendEmail);
+  if (member) {
+    if (member.id === referrer.momence_member_id) {
+      return { outcome: 'rejected', reason: 'self-referral' };
+    }
+    if (member.visits.total > 0 || member.visits.openAreaVisits > 0) {
+      return { outcome: 'rejected', reason: 'existing-customer' };
+    }
+    const hasBookings = await memberHasBookings(String(member.id));
+    if (hasBookings === true) {
+      return { outcome: 'rejected', reason: 'existing-customer' };
+    }
+  }
+
+  const tier = await getTier(referrer.discount_percent);
+  if (!tier) return { outcome: 'unavailable', reason: 'tier-missing' };
+  const tagId = await getTagIdByName(tier.tag_name);
+  if (tagId === null) {
+    log.error(`Momence tag "${tier.tag_name}" not found — create it in the dashboard first`);
+    return { outcome: 'unavailable', reason: 'tag-missing' };
+  }
+
+  const { data: inserted, error } = await db
+    .from(TABLE)
+    .insert({
+      referrer_id: referrer.id,
+      code: referrer.code,
+      discount_percent: referrer.discount_percent,
+      tag_name: tier.tag_name,
+      friend_first_name: params.firstName.trim(),
+      friend_last_name: params.lastName.trim(),
+      friend_email: friendEmail,
+    })
+    .select('id')
+    .single();
+  if (error || !inserted) {
+    if (error?.code === '23505') return { outcome: 'already-redeemed', status: 'pending' };
+    log.error('Redemption insert failed', error);
+    return { outcome: 'unavailable', reason: 'db-insert-failed' };
+  }
+
+  // Momence work happens BEFORE the status flip (house rule): a failure leaves
+  // no live discount, so drop the pending row and let the friend retry.
+  let memberId: number;
+  let memberCreated = false;
+  try {
+    if (member) {
+      memberId = member.id;
+    } else {
+      memberId = await createMember({
+        email: friendEmail,
+        firstName: params.firstName.trim(),
+        lastName: params.lastName.trim(),
+      });
+      memberCreated = true;
+    }
+    await assignMemberTag(memberId, tagId);
+  } catch (momenceError) {
+    await db.from(TABLE).delete().eq('id', inserted.id);
+    log.error(`Momence write failed for ${friendEmail}`, momenceError);
+    return { outcome: 'unavailable', reason: 'momence-write-failed' };
+  }
+
+  const { data: updated } = await db
+    .from(TABLE)
+    .update({ status: 'redeemed', friend_momence_member_id: memberId })
+    .eq('id', inserted.id)
+    .eq('status', 'pending')
+    .select('id');
+  if (!updated || updated.length === 0) {
+    // Should be unreachable (nothing else touches pending rows this young),
+    // but the tag assignment above is idempotent either way.
+    return { outcome: 'already-redeemed', status: 'redeemed' };
+  }
+
+  try {
+    await sendTemplate({
+      to: friendEmail,
+      template: 'referral-redeemed',
+      props: {
+        firstName: params.firstName.trim(),
+        referrerName: referrer.display_name,
+        discountPercent: referrer.discount_percent,
+        bookUrl: bookUrl(referrer.code),
+      },
+    });
+  } catch (emailError) {
+    // The discount is live; a lost email must not undo it.
+    log.warn(`Redemption email failed for ${friendEmail}`, emailError);
+  }
+
+  await captureEvent({
+    distinctId: friendEmail,
+    event: 'referral_redeemed',
+    properties: {
+      code: referrer.code,
+      referrer_type: referrer.referrer_type,
+      discount_percent: referrer.discount_percent,
+      member_created: memberCreated,
+    },
+  });
+
+  return { outcome: 'redeemed' };
+}

--- a/apps/integrations/src/lib/referral/referrers.ts
+++ b/apps/integrations/src/lib/referral/referrers.ts
@@ -1,0 +1,140 @@
+// Referrer creation. Members become referrers lazily — the first visit to the
+// /account referral card (or an admin action) creates the row and mints the
+// code. Partner referrers are always admin-created against an existing
+// partners row.
+
+import { createWebhookLogger } from '@pyre/webhook-core';
+import { captureEvent } from '@/lib/analytics/posthog';
+import { getDb, type ReferrerRow } from '@/lib/db';
+import { getPartner } from '@/lib/partner/registry';
+import { codeCandidates, isValidCode, normalizeCode } from './codes';
+import { getReferrerByMemberId } from './registry';
+
+const log = createWebhookLogger('Referrals');
+
+export type GetOrCreateResult =
+  | { outcome: 'found'; referrer: ReferrerRow }
+  | { outcome: 'created'; referrer: ReferrerRow }
+  | { outcome: 'unavailable'; reason: string };
+
+/**
+ * The member's referrer row, minting one (with a fresh code) if absent.
+ * Insert races resolve via the unique index on momence_member_id: the loser
+ * re-reads the winner's row.
+ */
+export async function getOrCreateMemberReferrer(params: {
+  momenceMemberId: number;
+  email: string;
+  firstName: string;
+}): Promise<GetOrCreateResult> {
+  const db = getDb();
+  if (!db) return { outcome: 'unavailable', reason: 'db-not-configured' };
+
+  const existing = await getReferrerByMemberId(params.momenceMemberId);
+  if (existing) return { outcome: 'found', referrer: existing };
+
+  const email = params.email.trim().toLowerCase();
+  const displayName = params.firstName.trim() || 'A friend';
+
+  for (const code of codeCandidates(params.firstName)) {
+    const { data, error } = await db
+      .from('referrers')
+      .insert({
+        referrer_type: 'member',
+        momence_member_id: params.momenceMemberId,
+        email,
+        display_name: displayName,
+        code,
+      })
+      .select('*')
+      .single<ReferrerRow>();
+
+    if (data) {
+      await captureEvent({
+        distinctId: email,
+        event: 'referral_code_created',
+        properties: { code, referrer_type: 'member' },
+      });
+      return { outcome: 'created', referrer: data };
+    }
+
+    if (error?.code === '23505') {
+      // Either the code collided (try the next candidate) or a concurrent
+      // request already created this member's row (return it).
+      const raced = await getReferrerByMemberId(params.momenceMemberId);
+      if (raced) return { outcome: 'found', referrer: raced };
+      continue;
+    }
+
+    log.error('Referrer insert failed', error);
+    return { outcome: 'unavailable', reason: 'db-insert-failed' };
+  }
+
+  log.error(`Ran out of code candidates for member ${params.momenceMemberId}`);
+  return { outcome: 'unavailable', reason: 'code-generation-exhausted' };
+}
+
+export type CreatePartnerReferrerResult =
+  | { outcome: 'created'; referrer: ReferrerRow }
+  | { outcome: 'exists'; referrer: ReferrerRow }
+  | { outcome: 'unavailable'; reason: string };
+
+/**
+ * Admin-created referrer for a partner business. The code is chosen by the
+ * admin (e.g. BFT15 to match the printed voucher cards).
+ */
+export async function createPartnerReferrer(params: {
+  partnerSlug: string;
+  code: string;
+  discountPercent?: number;
+  createdBy: string;
+}): Promise<CreatePartnerReferrerResult> {
+  const db = getDb();
+  if (!db) return { outcome: 'unavailable', reason: 'db-not-configured' };
+
+  const partner = await getPartner(params.partnerSlug);
+  if (!partner) return { outcome: 'unavailable', reason: 'unknown-partner' };
+
+  const code = normalizeCode(params.code);
+  if (!isValidCode(code)) return { outcome: 'unavailable', reason: 'invalid-code' };
+
+  const { data, error } = await db
+    .from('referrers')
+    .insert({
+      referrer_type: 'partner',
+      partner_slug: partner.slug,
+      display_name: partner.name,
+      code,
+      ...(params.discountPercent != null && { discount_percent: params.discountPercent }),
+      created_by: params.createdBy,
+    })
+    .select('*')
+    .single<ReferrerRow>();
+
+  if (data) {
+    await captureEvent({
+      distinctId: partner.slug,
+      event: 'referral_code_created',
+      properties: { code, referrer_type: 'partner', partner: partner.slug },
+    });
+    return { outcome: 'created', referrer: data };
+  }
+
+  if (error?.code === '23505') {
+    // Distinguish "this partner already has a code" from "that code is taken".
+    const { data: existing } = await db
+      .from('referrers')
+      .select('*')
+      .eq('partner_slug', partner.slug)
+      .maybeSingle<ReferrerRow>();
+    if (existing) return { outcome: 'exists', referrer: existing };
+    return { outcome: 'unavailable', reason: 'code-taken' };
+  }
+
+  // FK violation on discount_percent = tier missing. Surface it as its own
+  // reason so the admin UI can say "create the tier first".
+  if (error?.code === '23503') return { outcome: 'unavailable', reason: 'unknown-tier' };
+
+  log.error('Partner referrer insert failed', error);
+  return { outcome: 'unavailable', reason: 'db-insert-failed' };
+}

--- a/apps/integrations/src/lib/referral/registry.ts
+++ b/apps/integrations/src/lib/referral/registry.ts
@@ -1,0 +1,135 @@
+// Referrer + tier registry for the referral program. Source of truth is the
+// `referrers` / `referral_tiers` tables (managed from /admin/referrals and
+// grown implicitly by /api/referral/me get-or-create). Same brief in-process
+// cache shape as lib/partner/registry.ts — but keyed lookups hit the DB
+// directly because referrers, unlike partners, are unbounded (every /account
+// visitor becomes one).
+
+import { getDb, type ReferralTierRow, type ReferrerRow } from '@/lib/db';
+
+const CACHE_TTL_MS = 30_000;
+let tierCache: { rows: ReferralTierRow[]; at: number } | null = null;
+
+export function invalidateTierCache(): void {
+  tierCache = null;
+}
+
+/** All tier rows (cached ~30s), or null when Supabase is down. */
+export async function listTiers(force = false): Promise<ReferralTierRow[] | null> {
+  const db = getDb();
+  if (!db) return null;
+
+  if (!force && tierCache && Date.now() - tierCache.at < CACHE_TTL_MS) return tierCache.rows;
+
+  const { data, error } = await db.from('referral_tiers').select('*').order('percent');
+  if (error) {
+    console.error('[referrals] tier fetch failed:', error.message);
+    // A stale tier map beats treating a query error as "no tiers" — that
+    // would reject every redemption.
+    return tierCache?.rows ?? null;
+  }
+
+  tierCache = { rows: data as ReferralTierRow[], at: Date.now() };
+  return tierCache.rows;
+}
+
+/** The tier a referrer's friends get, or null when unknown/unavailable. */
+export async function getTier(percent: number): Promise<ReferralTierRow | null> {
+  const tiers = await listTiers();
+  return tiers?.find((t) => t.percent === percent) ?? null;
+}
+
+export type ReferrerLookup =
+  | { status: 'found'; referrer: ReferrerRow }
+  | { status: 'disabled'; referrer: ReferrerRow }
+  | { status: 'unknown' }
+  | { status: 'unavailable' };
+
+/**
+ * Intake-path lookup by code. Keeps "no such code" (404 on the landing page)
+ * distinct from "storage is down" (503) — same contract as lookupPartner.
+ */
+export async function lookupReferrerByCode(code: string): Promise<ReferrerLookup> {
+  const db = getDb();
+  if (!db) return { status: 'unavailable' };
+
+  const normalized = code.trim().toUpperCase();
+  if (!/^[A-Z0-9]{3,16}$/.test(normalized)) return { status: 'unknown' };
+
+  const { data, error } = await db
+    .from('referrers')
+    .select('*')
+    .eq('code', normalized)
+    .maybeSingle<ReferrerRow>();
+  if (error) {
+    console.error('[referrals] code lookup failed:', error.message);
+    return { status: 'unavailable' };
+  }
+  if (!data) return { status: 'unknown' };
+  return data.enabled
+    ? { status: 'found', referrer: data }
+    : { status: 'disabled', referrer: data };
+}
+
+/** The referrer row behind a Momence member id, enabled or not. */
+export async function getReferrerByMemberId(momenceMemberId: number): Promise<ReferrerRow | null> {
+  const db = getDb();
+  if (!db) return null;
+
+  const { data, error } = await db
+    .from('referrers')
+    .select('*')
+    .eq('momence_member_id', momenceMemberId)
+    .maybeSingle<ReferrerRow>();
+  if (error) {
+    console.error('[referrals] member lookup failed:', error.message);
+    return null;
+  }
+  return data;
+}
+
+/** The referrer row by primary key, enabled or not. */
+export async function getReferrer(id: string): Promise<ReferrerRow | null> {
+  const db = getDb();
+  if (!db) return null;
+
+  const { data, error } = await db
+    .from('referrers')
+    .select('*')
+    .eq('id', id)
+    .maybeSingle<ReferrerRow>();
+  if (error) {
+    console.error('[referrals] referrer fetch failed:', error.message);
+    return null;
+  }
+  return data;
+}
+
+/**
+ * The Momence tag carrying the referrer reward Price Rule. Like tier tags, the
+ * tag and its rule are created by hand in the Momence dashboard.
+ */
+export function getRewardTagName(): string {
+  return (
+    import.meta.env.REFERRAL_REWARD_TAG_NAME ??
+    process.env.REFERRAL_REWARD_TAG_NAME ??
+    'referral-reward'
+  );
+}
+
+/** How long a redeemed-but-unbooked discount lives before the sweep expires it. */
+export function getRedemptionExpiryDays(): number {
+  const raw = import.meta.env.REFERRAL_EXPIRY_DAYS ?? process.env.REFERRAL_EXPIRY_DAYS;
+  const parsed = Number.parseInt(raw ?? '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 60;
+}
+
+/** How long an unused referrer reward lives before the sweep expires it. */
+export const REWARD_EXPIRY_DAYS = 90;
+
+/** Where a code's shareable link points. */
+export function referralUrl(code: string): string {
+  const site =
+    import.meta.env.PUBLIC_SITE_URL ?? process.env.PUBLIC_SITE_URL ?? 'https://pyresauna.com';
+  return `${site}/r/${code}`;
+}

--- a/apps/integrations/src/lib/webhooks/momence.ts
+++ b/apps/integrations/src/lib/webhooks/momence.ts
@@ -372,3 +372,44 @@ export async function isMemberFirstBooking(
     return null;
   }
 }
+
+// Same endpoint as isMemberFirstBooking, but asked from the other side: does
+// this member have ANY session booking at all? The referral redemption path
+// uses it to enforce first-time-customers-only. Returns null when the answer
+// can't be determined; the caller decides which way to fail.
+export async function memberHasBookings(memberId: string): Promise<boolean | null> {
+  try {
+    const accessToken = await getHostAccessToken();
+
+    // includeCancelled=true: someone who booked and cancelled has still been a
+    // customer — the referral discount is for people who never booked.
+    const params = new URLSearchParams({
+      page: '0',
+      pageSize: '1',
+      sortOrder: 'DESC',
+      includeCancelled: 'true',
+    });
+    const url = `${MOMENCE_API_V2}/host/members/${memberId}/sessions?${params}`;
+
+    const response = await fetch(url, {
+      headers: { Authorization: `Bearer ${accessToken}`, Accept: 'application/json' },
+    });
+    const responseText = await response.text();
+    if (!response.ok) {
+      log.warn(
+        `Booking-history check returned ${response.status} for member ${memberId}`,
+        responseText.slice(0, 500)
+      );
+      return null;
+    }
+
+    const data = JSON.parse(responseText);
+    const total: unknown = data.pagination?.total ?? data.pagination?.totalCount;
+    if (typeof total === 'number') return total > 0;
+    if (Array.isArray(data.payload)) return data.payload.length > 0;
+    return null;
+  } catch (error) {
+    log.warn(`Booking-history check failed for member ${memberId}`, error);
+    return null;
+  }
+}

--- a/apps/integrations/src/pages/admin/referrals.astro
+++ b/apps/integrations/src/pages/admin/referrals.astro
@@ -1,0 +1,15 @@
+---
+// Referral program: referrer codes, the redemption queue, the reward ledger,
+// and discount tiers. Viewable with the page grant, editable with admin or
+// referrals:manage — the /api/admin/referrals route re-checks on every
+// request, so this page gate is UX and the API gate is the security boundary.
+import { ReferralsManager } from '@/components/admin/ReferralsManager';
+import AdminLayout from '@/layouts/AdminLayout.astro';
+---
+
+<AdminLayout
+  title="Referrals"
+  subtitle="Personal referral codes for members and partner businesses, who redeemed them, and the double-sided rewards. Momence still owns the discounts themselves — the customer tags and their price rules."
+>
+  <ReferralsManager client:load />
+</AdminLayout>

--- a/apps/integrations/src/pages/api/admin/referrals.ts
+++ b/apps/integrations/src/pages/api/admin/referrals.ts
@@ -1,0 +1,289 @@
+// The referral program's admin API behind /admin/referrals: referrer registry
+// (members + partners), the redemption queue, the reward ledger, and the tier
+// map. Reads need the page grant; every mutation needs admin or
+// referrals:manage because they all end in a Momence tag change.
+//
+// There is no DELETE anywhere: redemption and reward rows are the audit trail,
+// and referrer rows anchor them.
+
+import type { APIRoute } from 'astro';
+import { REFERRALS_MANAGE } from '@/components/admin/adminTools';
+import { assertSameOrigin, requirePage } from '@/lib/auth/admin';
+import {
+  getDb,
+  type ReferralRedemptionRow,
+  type ReferralRewardRow,
+  type ReferralTierRow,
+  type ReferrerRow,
+} from '@/lib/db';
+import { findMemberByEmail, getTagIdByName, invalidateTagCache } from '@/lib/momence/host-api';
+import { revokeRedemption, revokeReward } from '@/lib/referral/admin-actions';
+import { createPartnerReferrer, getOrCreateMemberReferrer } from '@/lib/referral/referrers';
+import { getRewardTagName, invalidateTierCache } from '@/lib/referral/registry';
+
+export const prerender = false;
+
+const PAGE = '/admin/referrals';
+const JSON_HEADERS = { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' };
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: JSON_HEADERS });
+}
+
+const REDEMPTION_STATUSES = ['pending', 'redeemed', 'converted', 'expired', 'revoked'] as const;
+const DEFAULT_LIMIT = 100;
+const MAX_LIMIT = 500;
+
+export const GET: APIRoute = async ({ cookies, url }) => {
+  const gate = await requirePage(cookies, PAGE);
+  if (gate instanceof Response) return gate;
+
+  const db = getDb();
+  if (!db) return json({ error: 'Storage unavailable' }, 503);
+
+  const limit = Math.min(
+    MAX_LIMIT,
+    Math.max(1, Number(url.searchParams.get('limit')) || DEFAULT_LIMIT)
+  );
+
+  let referrerQuery = db
+    .from('referrers')
+    .select('*')
+    .order('created_at', { ascending: false })
+    .limit(limit);
+  const q = url.searchParams.get('q')?.trim();
+  if (q) {
+    const like = `%${q.replace(/[%_]/g, '')}%`;
+    referrerQuery = referrerQuery.or(
+      `code.ilike.${like},display_name.ilike.${like},email.ilike.${like},partner_slug.ilike.${like}`
+    );
+  }
+
+  let redemptionQuery = db
+    .from('referral_redemptions')
+    .select('*')
+    .order('created_at', { ascending: false })
+    .limit(limit);
+  const status = url.searchParams.get('status');
+  if (status) {
+    const wanted = status
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => (REDEMPTION_STATUSES as readonly string[]).includes(s));
+    if (wanted.length > 0) redemptionQuery = redemptionQuery.in('status', wanted);
+  }
+
+  const [
+    { data: referrers, error: referrersError },
+    { data: redemptions },
+    { data: rewards },
+    { data: tiers },
+    { data: allStatuses },
+  ] = await Promise.all([
+    referrerQuery,
+    redemptionQuery,
+    db.from('referral_rewards').select('*').order('granted_at', { ascending: false }).limit(limit),
+    db.from('referral_tiers').select('*').order('percent'),
+    db.from('referral_redemptions').select('status'),
+  ]);
+  if (referrersError) return json({ error: referrersError.message }, 500);
+
+  const counts: Record<string, number> = {};
+  for (const row of (allStatuses ?? []) as { status: string }[]) {
+    counts[row.status] = (counts[row.status] ?? 0) + 1;
+  }
+
+  // Does each tier's Momence tag (and the reward tag) actually exist? null =
+  // couldn't check. Same nag the partners page gives, cheap via the cached map.
+  const rewardTagName = getRewardTagName();
+  const tagStatus: Record<string, boolean | null> = {};
+  for (const tagName of [...(tiers ?? []).map((t) => t.tag_name), rewardTagName]) {
+    try {
+      tagStatus[tagName] = (await getTagIdByName(tagName)) !== null;
+    } catch {
+      tagStatus[tagName] = null;
+    }
+  }
+
+  return json({
+    referrers: (referrers ?? []) as ReferrerRow[],
+    redemptions: (redemptions ?? []) as ReferralRedemptionRow[],
+    rewards: (rewards ?? []) as ReferralRewardRow[],
+    tiers: (tiers ?? []) as ReferralTierRow[],
+    rewardTagName,
+    tagStatus,
+    counts,
+    canManage: gate.access.isAdmin || gate.access.pages.includes(REFERRALS_MANAGE),
+  });
+};
+
+export const POST: APIRoute = async ({ cookies, request }) => {
+  const gate = await requirePage(cookies, PAGE);
+  if (gate instanceof Response) return gate;
+  if (!gate.access.isAdmin && !gate.access.pages.includes(REFERRALS_MANAGE)) {
+    return json({ error: 'Forbidden' }, 403);
+  }
+  const crossOrigin = assertSameOrigin(request);
+  if (crossOrigin) return crossOrigin;
+
+  if (!request.headers.get('content-type')?.includes('application/json')) {
+    return json({ error: 'Expected application/json' }, 415);
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return json({ error: 'Invalid JSON body' }, 400);
+  }
+
+  const db = getDb();
+  if (!db) return json({ error: 'Storage unavailable' }, 503);
+
+  const actorEmail = (gate.user.email ?? '').toLowerCase();
+  const action = String(body.action ?? '');
+
+  try {
+    switch (action) {
+      case 'create-member-referrer': {
+        const email = String(body.email ?? '')
+          .trim()
+          .toLowerCase();
+        if (!email) return json({ error: 'Missing email' }, 400);
+        const member = await findMemberByEmail(email);
+        if (!member) return json({ error: `No Momence member found for ${email}` }, 404);
+        const result = await getOrCreateMemberReferrer({
+          momenceMemberId: member.id,
+          email,
+          firstName: member.firstName,
+        });
+        if (result.outcome === 'unavailable') return json({ error: result.reason }, 503);
+        return json({ ok: true, referrer: result.referrer, existed: result.outcome === 'found' });
+      }
+
+      case 'create-partner-referrer': {
+        const partnerSlug = String(body.partnerSlug ?? '').trim();
+        const code = String(body.code ?? '').trim();
+        if (!partnerSlug || !code) return json({ error: 'Missing partner or code' }, 400);
+        const discountPercent = Number(body.discountPercent);
+        const result = await createPartnerReferrer({
+          partnerSlug,
+          code,
+          ...(Number.isFinite(discountPercent) && { discountPercent }),
+          createdBy: actorEmail,
+        });
+        if (result.outcome === 'unavailable') {
+          const messages: Record<string, string> = {
+            'unknown-partner': 'No such partner — add it on /admin/partners first',
+            'invalid-code': 'Codes are 3-16 letters/digits',
+            'code-taken': 'That code is already in use',
+            'unknown-tier': 'No tier for that percent — create the tier first',
+          };
+          return json({ error: messages[result.reason] ?? result.reason }, 400);
+        }
+        return json({ ok: true, referrer: result.referrer, existed: result.outcome === 'exists' });
+      }
+
+      case 'update-referrer': {
+        const id = String(body.id ?? '');
+        if (!id) return json({ error: 'Missing id' }, 400);
+        const patch: Record<string, unknown> = { updated_by: actorEmail };
+        if (typeof body.enabled === 'boolean') patch.enabled = body.enabled;
+        if (body.discountPercent != null) {
+          const percent = Number(body.discountPercent);
+          if (!Number.isFinite(percent)) return json({ error: 'Invalid percent' }, 400);
+          patch.discount_percent = percent;
+        }
+        if (typeof body.notes === 'string') patch.notes = body.notes.trim() || null;
+        const { data, error } = await db
+          .from('referrers')
+          .update(patch)
+          .eq('id', id)
+          .select('*')
+          .maybeSingle<ReferrerRow>();
+        if (error) {
+          // FK violation = tier missing for the requested percent.
+          if (error.code === '23503') {
+            return json({ error: 'No tier for that percent — create the tier first' }, 400);
+          }
+          return json({ error: error.message }, 500);
+        }
+        if (!data) return json({ error: 'No such referrer' }, 404);
+        return json({ ok: true, referrer: data });
+      }
+
+      case 'create-tier': {
+        const percent = Number(body.percent);
+        const tagName = String(body.tagName ?? '').trim();
+        if (!Number.isFinite(percent) || percent <= 0 || percent >= 100 || !tagName) {
+          return json({ error: 'Tier needs a percent (1-99) and a Momence tag name' }, 400);
+        }
+        const { data, error } = await db
+          .from('referral_tiers')
+          .insert({ percent, tag_name: tagName })
+          .select('*')
+          .single<ReferralTierRow>();
+        if (error) {
+          if (error.code === '23505')
+            return json({ error: 'That percent or tag already exists' }, 409);
+          return json({ error: error.message }, 500);
+        }
+        invalidateTierCache();
+        await invalidateTagCache();
+        return json({ ok: true, tier: data });
+      }
+
+      case 'toggle-tier': {
+        const percent = Number(body.percent);
+        const enabled = Boolean(body.enabled);
+        const { data, error } = await db
+          .from('referral_tiers')
+          .update({ enabled })
+          .eq('percent', percent)
+          .select('*')
+          .maybeSingle<ReferralTierRow>();
+        if (error) return json({ error: error.message }, 500);
+        if (!data) return json({ error: 'No such tier' }, 404);
+        invalidateTierCache();
+        return json({ ok: true, tier: data });
+      }
+
+      case 'revoke-redemption': {
+        const id = String(body.id ?? '');
+        if (!id) return json({ error: 'Missing id' }, 400);
+        const result = await revokeRedemption(
+          id,
+          actorEmail,
+          typeof body.reason === 'string' ? body.reason : undefined
+        );
+        if (result.outcome === 'not-found') return json({ error: 'No such redemption' }, 404);
+        if (result.outcome === 'not-revocable') {
+          return json({ error: `Already ${result.status} — nothing to revoke` }, 409);
+        }
+        return json({ ok: true });
+      }
+
+      case 'revoke-reward': {
+        const id = String(body.id ?? '');
+        if (!id) return json({ error: 'Missing id' }, 400);
+        const result = await revokeReward(id, actorEmail);
+        if (result.outcome === 'not-found') return json({ error: 'No such reward' }, 404);
+        if (result.outcome === 'not-revocable') {
+          return json({ error: `Already ${result.status} — nothing to revoke` }, 409);
+        }
+        return json({ ok: true });
+      }
+
+      case 'refresh-tag-cache': {
+        await invalidateTagCache();
+        return json({ ok: true });
+      }
+
+      default:
+        return json({ error: `Unknown action: ${action || '(none)'}` }, 400);
+    }
+  } catch (error) {
+    console.error('[admin/referrals] Action failed', error);
+    return json({ error: error instanceof Error ? error.message : 'Action failed' }, 500);
+  }
+};

--- a/apps/integrations/src/pages/api/referral/lookup.ts
+++ b/apps/integrations/src/pages/api/referral/lookup.ts
@@ -1,0 +1,40 @@
+import type { APIRoute } from 'astro';
+import { isReferralAuthorized } from '@/lib/referral/api-auth';
+import { lookupReferrerByCode } from '@/lib/referral/registry';
+
+export const prerender = false;
+
+// Code lookup for the landing page's /r/{code} SSR render: enough to say
+// "Wes gave you 15% off", nothing more. Server-to-server only (Bearer auth) so
+// the codes aren't enumerable from a browser.
+
+function json(status: number, body: Record<string, unknown>): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export const GET: APIRoute = async ({ request, url }) => {
+  if (!isReferralAuthorized(request)) {
+    return json(401, { error: 'Unauthorized' });
+  }
+
+  const code = url.searchParams.get('code')?.trim() ?? '';
+  if (!code) return json(400, { error: 'Missing code' });
+
+  const lookup = await lookupReferrerByCode(code);
+  if (lookup.status === 'unavailable') return json(503, { error: 'storage-unavailable' });
+  if (lookup.status === 'unknown' || lookup.status === 'disabled') {
+    // Disabled looks identical to unknown from outside: the page 404s either
+    // way, and the difference is nobody's business but the admin queue's.
+    return json(404, { error: 'unknown-code' });
+  }
+
+  return json(200, {
+    code: lookup.referrer.code,
+    displayName: lookup.referrer.display_name,
+    discountPercent: lookup.referrer.discount_percent,
+    referrerType: lookup.referrer.referrer_type,
+  });
+};

--- a/apps/integrations/src/pages/api/referral/me.ts
+++ b/apps/integrations/src/pages/api/referral/me.ts
@@ -1,0 +1,100 @@
+import type { APIRoute } from 'astro';
+import { getDb } from '@/lib/db';
+import { findMemberByEmail } from '@/lib/momence/host-api';
+import { isReferralAuthorized } from '@/lib/referral/api-auth';
+import { getReferralClicks } from '@/lib/referral/codes';
+import { getOrCreateMemberReferrer } from '@/lib/referral/referrers';
+import { referralUrl } from '@/lib/referral/registry';
+
+export const prerender = false;
+
+// The /account referral card's data source: get-or-create the logged-in
+// member's referrer row and return their code + stats. Called server-to-server
+// by the landing page (which owns the Momence OAuth session); the member is
+// resolved by email through the HOST api because the OAuth profile id is not
+// guaranteed to be the host member id the webhooks report.
+//
+// Get-or-create is deliberate: every member who opens the card becomes a
+// referrer with a live code, no signup step.
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function json(status: number, body: Record<string, unknown>): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export const POST: APIRoute = async ({ request }) => {
+  if (!isReferralAuthorized(request)) {
+    return json(401, { error: 'Unauthorized' });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return json(400, { error: 'Invalid JSON' });
+  }
+
+  const email = typeof body.email === 'string' ? body.email.trim().toLowerCase() : '';
+  const firstName = typeof body.firstName === 'string' ? body.firstName.trim() : '';
+  if (!EMAIL_RE.test(email)) return json(400, { error: 'Invalid email' });
+
+  try {
+    const member = await findMemberByEmail(email);
+    if (!member) return json(404, { error: 'member-not-found' });
+
+    const result = await getOrCreateMemberReferrer({
+      momenceMemberId: member.id,
+      email,
+      firstName: firstName || member.firstName,
+    });
+    if (result.outcome === 'unavailable') return json(503, { error: result.reason });
+    const referrer = result.referrer;
+
+    const db = getDb();
+    let redemptions = 0;
+    let conversions = 0;
+    let rewardsEarned = 0;
+    let rewardsActive = 0;
+    if (db) {
+      const [{ count: redeemedCount }, { count: convertedCount }, { data: rewards }] =
+        await Promise.all([
+          db
+            .from('referral_redemptions')
+            .select('id', { count: 'exact', head: true })
+            .eq('referrer_id', referrer.id)
+            .in('status', ['redeemed', 'converted']),
+          db
+            .from('referral_redemptions')
+            .select('id', { count: 'exact', head: true })
+            .eq('referrer_id', referrer.id)
+            .eq('status', 'converted'),
+          db.from('referral_rewards').select('status').eq('referrer_id', referrer.id),
+        ]);
+      redemptions = redeemedCount ?? 0;
+      conversions = convertedCount ?? 0;
+      rewardsEarned = rewards?.length ?? 0;
+      rewardsActive = rewards?.filter((r) => r.status === 'granted').length ?? 0;
+    }
+
+    return json(200, {
+      code: referrer.code,
+      url: referralUrl(referrer.code),
+      discountPercent: referrer.discount_percent,
+      enabled: referrer.enabled,
+      stats: {
+        clicks: await getReferralClicks(referrer.code),
+        redemptions,
+        conversions,
+        rewardsEarned,
+        rewardsActive,
+      },
+    });
+  } catch (error) {
+    console.error('[Referral] /me failed', error);
+    return json(502, { error: 'Request failed' });
+  }
+};

--- a/apps/integrations/src/pages/api/referral/redeem.ts
+++ b/apps/integrations/src/pages/api/referral/redeem.ts
@@ -1,0 +1,76 @@
+import type { APIRoute } from 'astro';
+import { isReferralAuthorized } from '@/lib/referral/api-auth';
+import { redeemReferral } from '@/lib/referral/redemption';
+
+export const prerender = false;
+
+// Referral redemption intake. Called server-to-server by the landing page's
+// /api/referral-redemption route (which owns Turnstile + rate limiting) —
+// never by browsers, hence the shared-secret Bearer auth and no CORS.
+
+const MAX_NAME_LENGTH = 120;
+const MAX_EMAIL_LENGTH = 254;
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function json(status: number, body: Record<string, unknown>): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export const POST: APIRoute = async ({ request }) => {
+  if (!isReferralAuthorized(request)) {
+    return json(401, { error: 'Unauthorized' });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return json(400, { error: 'Invalid JSON' });
+  }
+
+  const code = typeof body.code === 'string' ? body.code.trim() : '';
+  const firstName = typeof body.firstName === 'string' ? body.firstName.trim() : '';
+  const lastName = typeof body.lastName === 'string' ? body.lastName.trim() : '';
+  const email = typeof body.email === 'string' ? body.email.trim().toLowerCase() : '';
+
+  if (
+    !code ||
+    !firstName ||
+    firstName.length > MAX_NAME_LENGTH ||
+    !lastName ||
+    lastName.length > MAX_NAME_LENGTH
+  ) {
+    return json(400, { error: 'Invalid name' });
+  }
+  if (!EMAIL_RE.test(email) || email.length > MAX_EMAIL_LENGTH) {
+    return json(400, { error: 'Invalid email' });
+  }
+
+  try {
+    const result = await redeemReferral({ code, firstName, lastName, email });
+
+    switch (result.outcome) {
+      case 'redeemed':
+        return json(200, { ok: true, result: 'redeemed' });
+      case 'already-redeemed':
+        // The friend already has (or had) a referral discount. Not an error —
+        // the relay surfaces friendly copy keyed on this result.
+        return json(200, { ok: true, result: 'already-redeemed' });
+      case 'rejected':
+        // 'unknown-code' is a caller bug or a dead link (400); the rest are
+        // policy rejections the form explains (409 keeps them distinct).
+        return json(result.reason === 'unknown-code' ? 400 : 409, {
+          ok: false,
+          result: result.reason,
+        });
+      case 'unavailable':
+        return json(503, { ok: false, error: result.reason });
+    }
+  } catch (error) {
+    console.error('[Referral] Redemption failed', error);
+    return json(502, { error: 'Request failed' });
+  }
+};

--- a/apps/integrations/src/pages/api/webhooks/momence.ts
+++ b/apps/integrations/src/pages/api/webhooks/momence.ts
@@ -10,6 +10,7 @@ import { trackBookingEvent } from '@/lib/analytics/track-booking';
 import { upsertResendContact } from '@/lib/email/audience';
 import { sendBookingConfirmationEmails } from '@/lib/email/triggers/booking-confirmation';
 import { resolveSession } from '@/lib/momence-events';
+import { handleReferralBooking, handleReferralCancellation } from '@/lib/referral/conversion';
 import { dispatchTrigger } from '@/lib/triggers/dispatch';
 import { instrumentWebhook, type TracedAPIRoute } from '@/lib/webhooks/instrument';
 import {
@@ -102,6 +103,20 @@ async function handleBookingEvent(
       sessionId: payload.sessionId,
       sessionBookingId: payload.sessionBookingId,
     });
+
+    // Referral conversion + reward consumption (best-effort by contract —
+    // handleReferralBooking catches its own errors).
+    await tracer.span(
+      'Handle referral booking',
+      () =>
+        handleReferralBooking({
+          sessionId: payload.sessionId,
+          sessionBookingId: payload.sessionBookingId,
+          targetMemberId: payload.targetMemberId,
+          memberEmail: member.email,
+        }),
+      { targetMemberId: payload.targetMemberId }
+    );
     return;
   }
 
@@ -115,6 +130,10 @@ async function handleBookingEvent(
   } catch (error) {
     log.warn(`Failed to track booking_cancelled for booking ${payload.sessionBookingId}`, error);
   }
+
+  // Flag a converted referral whose converting booking was cancelled (admin
+  // decides on clawback). Catches its own errors.
+  await handleReferralCancellation(payload.sessionBookingId);
 }
 
 async function handleMemberEvent(

--- a/apps/landing-page/src/components/ReferralRedeemForm.astro
+++ b/apps/landing-page/src/components/ReferralRedeemForm.astro
@@ -1,0 +1,380 @@
+---
+import signupForm from '../lib/signupForm';
+import type { ReferralFormCopy } from '../lib/referral';
+import { interpolate } from '../lib/referral';
+import Button from './Button.astro';
+
+// Referral redemption form. Same lazy-Turnstile + honeypot + timing mechanics
+// as PartnerVerifyForm, but submits to /api/referral-redemption and resolves
+// synchronously — no partner approval step, so success means the discount is
+// already live.
+
+interface Props {
+  code: string;
+  discountPercent: number;
+  copy: ReferralFormCopy;
+  turnstileTheme?: 'light' | 'dark' | 'auto';
+}
+
+const { code, discountPercent, copy, turnstileTheme = 'dark' } = Astro.props;
+
+const firstNameId = 'referral-redeem-first-name';
+const lastNameId = 'referral-redeem-last-name';
+const emailId = 'referral-redeem-email';
+
+const inputClass =
+  'w-full rounded-md border border-current/20 bg-[var(--pyre-creme)]/10 px-4 py-3 text-base text-[var(--pyre-creme)] placeholder:text-[var(--pyre-creme)]/50 focus:outline-none focus:ring-2 focus:ring-[var(--pyre-muted-gold)]';
+const labelClass = 'block font-mono-bold text-xs uppercase tracking-wide mb-1.5 text-left';
+---
+
+<div class="max-w-md mx-auto">
+  <form
+    class="flex flex-col gap-4"
+    novalidate
+    data-referral-redeem-form
+    data-code={code}
+    data-turnstile-theme={turnstileTheme}
+    data-antispam={JSON.stringify(signupForm.antiSpam)}
+    data-turnstile={JSON.stringify(signupForm.turnstile)}
+    data-submit-label={copy.submitLabel}
+    data-submitting-label={copy.submittingLabel}
+    data-success-title={copy.successTitle}
+    data-success-message={interpolate(copy.successMessage, { percent: discountPercent })}
+    data-error-message={copy.errorMessage}
+    data-rejections={JSON.stringify(copy.rejections)}
+  >
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <div>
+        <label for={firstNameId} class={labelClass}>{copy.firstNameLabel}</label>
+        <input
+          id={firstNameId}
+          name="firstName"
+          type="text"
+          required
+          autocomplete="given-name"
+          maxlength="60"
+          placeholder={copy.firstNamePlaceholder}
+          class={inputClass}
+          data-referral-redeem-first-name
+        />
+      </div>
+      <div>
+        <label for={lastNameId} class={labelClass}>{copy.lastNameLabel}</label>
+        <input
+          id={lastNameId}
+          name="lastName"
+          type="text"
+          required
+          autocomplete="family-name"
+          maxlength="60"
+          placeholder={copy.lastNamePlaceholder}
+          class={inputClass}
+          data-referral-redeem-last-name
+        />
+      </div>
+    </div>
+    <div>
+      <label for={emailId} class={labelClass}>{copy.emailLabel}</label>
+      <input
+        id={emailId}
+        name="email"
+        type="email"
+        required
+        inputmode="email"
+        autocomplete="email"
+        placeholder={copy.emailPlaceholder}
+        class={inputClass}
+        data-referral-redeem-email
+      />
+      <p class="mt-1.5 text-xs opacity-60 text-left">
+        {interpolate(copy.emailHelp, { percent: discountPercent })}
+      </p>
+    </div>
+
+    <!-- Honeypot fields (same subset as PartnerVerifyForm; no phone honeypot
+         is needed since this form has no phone field, but keeping the same
+         pair the relay checks) -->
+    <input type="text" name={signupForm.antiSpam.honeypotFields.website} tabindex="-1" autocomplete="off" aria-hidden="true" class="sr-only" />
+    <input type="email" name={signupForm.antiSpam.honeypotFields.confirmEmail} tabindex="-1" autocomplete="off" aria-hidden="true" style="position: absolute; left: -9999px; visibility: hidden;" />
+    <input type="hidden" name={signupForm.antiSpam.timestampField} value="" />
+
+    <Button type="submit" variant="primary" size="lg" class="w-full">
+      {copy.submitLabel}
+    </Button>
+  </form>
+
+  <div class="flex justify-center mt-4" data-turnstile-container></div>
+
+  <p aria-live="polite" class="mt-3 text-sm text-[var(--pyre-burnt-orange)]" data-referral-redeem-error></p>
+  <div role="status" class="mt-3 hidden" data-referral-redeem-success>
+    <p class="font-primary-semibold text-lg text-green-400" data-referral-redeem-success-title></p>
+    <p class="mt-1 text-sm text-[var(--pyre-creme)]/80" data-referral-redeem-success-message></p>
+  </div>
+</div>
+
+<script>
+  (() => {
+    interface TurnstileApi {
+      render(
+        container: HTMLElement,
+        options: {
+          sitekey: string;
+          theme?: string;
+          size?: string;
+          callback?: (token: string) => void;
+          'error-callback'?: () => void;
+          'expired-callback'?: () => void;
+        }
+      ): string;
+      reset(widgetId?: string): void;
+      remove(widgetId?: string): void;
+    }
+    const w = window as unknown as Window & { turnstile?: TurnstileApi };
+
+    const widgetIds = new Map<HTMLElement, string>();
+    let turnstileScriptPromise: Promise<void> | null = null;
+
+    function loadTurnstileScript(): Promise<void> {
+      if (typeof w.turnstile !== 'undefined') return Promise.resolve();
+      if (turnstileScriptPromise) return turnstileScriptPromise;
+
+      turnstileScriptPromise = new Promise<void>((resolve, reject) => {
+        const existing = document.querySelector<HTMLScriptElement>('script[data-turnstile-loader]');
+        const target = existing ?? document.createElement('script');
+        if (!existing) {
+          target.src = 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit';
+          target.async = true;
+          target.defer = true;
+          target.dataset.turnstileLoader = 'true';
+        } else if (existing.dataset.turnstileLoaded === 'true') {
+          if (typeof w.turnstile !== 'undefined') resolve();
+          else reject(new Error('Turnstile loaded but unavailable'));
+          return;
+        } else if (existing.dataset.turnstileError === 'true') {
+          reject(new Error('Turnstile failed to load'));
+          return;
+        }
+        target.addEventListener('load', () => {
+          target.dataset.turnstileLoaded = 'true';
+          if (typeof w.turnstile !== 'undefined') resolve();
+          else reject(new Error('Turnstile loaded but unavailable'));
+        }, { once: true });
+        target.addEventListener('error', () => {
+          target.dataset.turnstileError = 'true';
+          reject(new Error('Turnstile failed to load'));
+        }, { once: true });
+        if (!existing) document.head.appendChild(target);
+      }).catch((error) => {
+        turnstileScriptPromise = null;
+        throw error;
+      });
+
+      return turnstileScriptPromise;
+    }
+
+    function initReferralForms() {
+      const forms = document.querySelectorAll<HTMLFormElement>('[data-referral-redeem-form]');
+
+      forms.forEach((form) => {
+        if (form.dataset.referralRedeemInit === 'true') return;
+        form.dataset.referralRedeemInit = 'true';
+
+        const antiSpamConfig = JSON.parse(form.getAttribute('data-antispam') || '{}');
+        const turnstileConfig = JSON.parse(form.getAttribute('data-turnstile') || '{}');
+        const turnstileTheme = form.getAttribute('data-turnstile-theme') || 'auto';
+        const rejections: Record<string, string> = JSON.parse(
+          form.getAttribute('data-rejections') || '{}'
+        );
+        let turnstileToken = '';
+        let turnstileRequested = false;
+
+        const timestampField = form.querySelector(
+          `input[name="${antiSpamConfig.timestampField}"]`
+        ) as HTMLInputElement | null;
+        if (timestampField) timestampField.value = Date.now().toString();
+
+        const container = form.parentElement!;
+        const firstNameInput = form.querySelector(
+          '[data-referral-redeem-first-name]'
+        ) as HTMLInputElement;
+        const lastNameInput = form.querySelector(
+          '[data-referral-redeem-last-name]'
+        ) as HTMLInputElement;
+        const emailInput = form.querySelector('[data-referral-redeem-email]') as HTMLInputElement;
+        const errorEl = container.querySelector('[data-referral-redeem-error]') as HTMLElement;
+        const successEl = container.querySelector('[data-referral-redeem-success]') as HTMLElement;
+        const successTitleEl = container.querySelector(
+          '[data-referral-redeem-success-title]'
+        ) as HTMLElement;
+        const successMessageEl = container.querySelector(
+          '[data-referral-redeem-success-message]'
+        ) as HTMLElement;
+        const turnstileContainer = container.querySelector('[data-turnstile-container]') as HTMLElement;
+
+        function initTurnstile() {
+          if (typeof w.turnstile === 'undefined' || !turnstileConfig.siteKey || !turnstileContainer) return;
+          const existingId = widgetIds.get(turnstileContainer);
+          if (existingId) {
+            try { w.turnstile.remove(existingId); } catch {}
+          }
+          turnstileContainer.innerHTML = '';
+          const wId = w.turnstile.render(turnstileContainer, {
+            sitekey: turnstileConfig.siteKey,
+            theme: turnstileTheme as 'light' | 'dark' | 'auto',
+            size: turnstileConfig.size || 'normal',
+            callback: (token: string) => { turnstileToken = token; },
+            'error-callback': () => { turnstileToken = ''; },
+            'expired-callback': () => { turnstileToken = ''; },
+          });
+          widgetIds.set(turnstileContainer, wId);
+        }
+
+        function requestTurnstile() {
+          if (turnstileRequested || !turnstileConfig.siteKey || !turnstileContainer) return;
+          turnstileRequested = true;
+          loadTurnstileScript()
+            .then(initTurnstile)
+            .catch(() => {
+              if (errorEl) errorEl.textContent = 'Security check could not load. Please try again.';
+            });
+        }
+
+        const observer = new IntersectionObserver(
+          (entries) => {
+            if (entries.some((entry) => entry.isIntersecting)) {
+              observer.disconnect();
+              requestTurnstile();
+            }
+          },
+          { rootMargin: '200px 0px', threshold: 0 }
+        );
+        observer.observe(form);
+        form.addEventListener('focusin', requestTurnstile, { passive: true });
+
+        form.addEventListener('submit', async (event) => {
+          event.preventDefault();
+          errorEl.textContent = '';
+
+          const firstName = firstNameInput.value.trim();
+          const lastName = lastNameInput.value.trim();
+          const email = emailInput.value.trim();
+          const emailValid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+
+          if (!firstName) {
+            errorEl.textContent = 'Please enter your first name.';
+            firstNameInput.focus();
+            return;
+          }
+          if (!lastName) {
+            errorEl.textContent = 'Please enter your last name.';
+            lastNameInput.focus();
+            return;
+          }
+          if (!emailValid) {
+            errorEl.textContent = 'Please enter a valid email.';
+            emailInput.focus();
+            return;
+          }
+          if (turnstileConfig.siteKey && !turnstileToken) {
+            requestTurnstile();
+            errorEl.textContent = 'Please complete the security check.';
+            return;
+          }
+
+          const submitBtn = form.querySelector('button[type="submit"]') as HTMLButtonElement;
+          if (submitBtn) {
+            submitBtn.disabled = true;
+            submitBtn.textContent = form.getAttribute('data-submitting-label') || 'Claiming…';
+          }
+
+          const payload: Record<string, string> = {
+            code: form.getAttribute('data-code') || '',
+            firstName,
+            lastName,
+            email,
+            turnstileToken,
+          };
+          for (const field of [
+            antiSpamConfig.honeypotFields?.website,
+            antiSpamConfig.honeypotFields?.confirmEmail,
+          ]) {
+            if (!field) continue;
+            const input = form.querySelector(`input[name="${field}"]`) as HTMLInputElement | null;
+            payload[field as string] = input?.value ?? '';
+          }
+          if (timestampField) payload[antiSpamConfig.timestampField] = timestampField.value;
+
+          const restoreSubmit = () => {
+            if (submitBtn) {
+              submitBtn.disabled = false;
+              submitBtn.textContent = form.getAttribute('data-submit-label') || 'Submit';
+            }
+            if (typeof w.turnstile !== 'undefined') w.turnstile.reset();
+            turnstileToken = '';
+          };
+
+          try {
+            const response = await fetch('/api/referral-redemption', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(payload),
+            });
+            const result = await response.json().catch(() => ({}));
+
+            const analyticsWindow = window as {
+              posthog?: {
+                identify: (id: string) => void;
+                capture: (event: string, properties?: Record<string, unknown>) => void;
+              };
+              pyreAttribution?: () => Record<string, unknown>;
+            };
+
+            if (response.ok && result.ok) {
+              form.classList.add('hidden');
+              if (turnstileContainer) turnstileContainer.classList.add('hidden');
+              successTitleEl.textContent = form.getAttribute('data-success-title') || 'You’re in!';
+              successMessageEl.textContent =
+                form.getAttribute('data-success-message') || 'Your discount is live.';
+              successEl.classList.remove('hidden');
+
+              if (analyticsWindow.posthog) {
+                analyticsWindow.posthog.identify(email);
+                analyticsWindow.posthog.capture('referral_redemption_submitted', {
+                  code: payload.code,
+                  email,
+                  ...(analyticsWindow.pyreAttribution?.() ?? {}),
+                });
+              }
+            } else if (response.ok && result.result && rejections[result.result]) {
+              // Policy rejection with friendly copy — leave the form usable so
+              // a typo'd email can be corrected.
+              errorEl.textContent = rejections[result.result];
+              restoreSubmit();
+              if (analyticsWindow.posthog) {
+                analyticsWindow.posthog.capture('referral_redemption_rejected', {
+                  code: payload.code,
+                  reason: result.result,
+                });
+              }
+            } else {
+              errorEl.textContent =
+                result.error || form.getAttribute('data-error-message') || 'Something went wrong.';
+              restoreSubmit();
+            }
+          } catch {
+            errorEl.textContent =
+              form.getAttribute('data-error-message') || 'Something went wrong. Please try again.';
+            restoreSubmit();
+          }
+        });
+      });
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', initReferralForms, { once: true });
+    } else {
+      initReferralForms();
+    }
+    document.addEventListener('astro:page-load', initReferralForms);
+  })();
+</script>

--- a/apps/landing-page/src/components/account/AccountDashboard.tsx
+++ b/apps/landing-page/src/components/account/AccountDashboard.tsx
@@ -8,6 +8,7 @@ import { CreditsCard } from './CreditsCard';
 import { MemberDataProvider } from './MemberDataProvider';
 import { MembershipCard } from './MembershipCard';
 import { ProfileCard } from './ProfileCard';
+import { ReferralCard } from './ReferralCard';
 import { SessionsList } from './SessionsList';
 
 export function AccountDashboard() {
@@ -91,6 +92,11 @@ export function AccountDashboard() {
           </div>
         </div>
       </MemberDataProvider>
+
+      {/* Referral section */}
+      <div id="referral" className="mt-6">
+        <ReferralCard />
+      </div>
 
       {/* Sessions section */}
       <div id="sessions" className="mt-8">

--- a/apps/landing-page/src/components/account/ReferralCard.tsx
+++ b/apps/landing-page/src/components/account/ReferralCard.tsx
@@ -1,0 +1,126 @@
+// ReferralCard component
+// The member's personal referral code, shareable link, and stats.
+
+import { useState } from 'react';
+import { useReferral } from '@/hooks/useReferral';
+import { accountConfig } from '@/lib/account-config';
+
+const copy = accountConfig.referral;
+
+export function ReferralCard() {
+  const { referral, loading, error } = useReferral();
+  const [copied, setCopied] = useState(false);
+
+  if (loading) {
+    return (
+      <div className="bg-[var(--pyre-red)] text-[var(--pyre-creme)] rounded-lg p-6">
+        <div className="h-6 w-48 bg-[var(--pyre-creme)]/20 rounded animate-pulse mb-4" />
+        <div className="h-10 w-32 bg-[var(--pyre-creme)]/20 rounded animate-pulse mb-4" />
+        <div className="h-4 w-full bg-[var(--pyre-creme)]/20 rounded animate-pulse" />
+      </div>
+    );
+  }
+
+  if (error || !referral) {
+    return (
+      <div className="bg-[var(--pyre-red)] text-[var(--pyre-creme)] rounded-lg p-6">
+        <h2 className="font-mono-bold text-lg uppercase tracking-wide mb-4">{copy.title}</h2>
+        <p className="text-sm opacity-80">{copy.errorState}</p>
+      </div>
+    );
+  }
+
+  if (!referral.enabled) {
+    return (
+      <div className="bg-[var(--pyre-red)] text-[var(--pyre-creme)] rounded-lg p-6">
+        <h2 className="font-mono-bold text-lg uppercase tracking-wide mb-4">{copy.title}</h2>
+        <p className="text-sm opacity-80">{copy.disabledState}</p>
+      </div>
+    );
+  }
+
+  const copyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(referral.url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard unavailable — the visible URL below is selectable.
+    }
+  };
+
+  const share = async () => {
+    const text = copy.shareText(referral.url, referral.discountPercent);
+    if (navigator.share) {
+      try {
+        await navigator.share({ text, url: referral.url });
+        return;
+      } catch {
+        // Cancelled or unsupported — fall through to copy.
+      }
+    }
+    await copyLink();
+  };
+
+  return (
+    <div className="bg-[var(--pyre-red)] text-[var(--pyre-creme)] rounded-lg p-6">
+      <h2 className="font-mono-bold text-lg uppercase tracking-wide mb-2">{copy.title}</h2>
+      <p className="text-sm opacity-80 mb-4">{copy.subtitle}</p>
+
+      {referral.stats.rewardsActive > 0 && (
+        <p className="inline-block rounded-full bg-[var(--pyre-creme)]/15 px-3 py-1 font-mono-bold text-xs uppercase tracking-wide mb-4">
+          {copy.rewardActiveBadge}
+        </p>
+      )}
+
+      <div className="mb-4">
+        <p className="font-mono-bold text-xs uppercase tracking-wide opacity-70 mb-1">
+          {copy.codeLabel}
+        </p>
+        <p className="font-mono-bold text-3xl tracking-wide">{referral.code}</p>
+      </div>
+
+      <div className="mb-5">
+        <p className="font-mono-bold text-xs uppercase tracking-wide opacity-70 mb-1.5">
+          {copy.linkLabel}
+        </p>
+        <div className="flex flex-col sm:flex-row gap-2">
+          <span className="flex-1 min-w-0 truncate rounded-md bg-[var(--pyre-creme)]/10 px-3 py-2 text-sm select-all">
+            {referral.url}
+          </span>
+          <div className="flex gap-2 shrink-0">
+            <button
+              type="button"
+              onClick={copyLink}
+              className="inline-flex items-center justify-center rounded px-3 py-2 font-mono-bold text-xs uppercase tracking-wide bg-[var(--pyre-creme)] text-[var(--pyre-red)] hover:opacity-90 transition-opacity"
+            >
+              {copied ? copy.copiedLabel : copy.copyButton}
+            </button>
+            <button
+              type="button"
+              onClick={share}
+              className="inline-flex items-center justify-center rounded px-3 py-2 font-mono-bold text-xs uppercase tracking-wide border border-[var(--pyre-creme)]/50 hover:bg-[var(--pyre-creme)]/10 transition-colors"
+            >
+              {copy.shareButton}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-3 gap-3 text-center">
+        <ReferralStat label={copy.stats.clicksLabel} value={referral.stats.clicks} />
+        <ReferralStat label={copy.stats.redemptionsLabel} value={referral.stats.redemptions} />
+        <ReferralStat label={copy.stats.conversionsLabel} value={referral.stats.conversions} />
+      </div>
+    </div>
+  );
+}
+
+function ReferralStat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-md bg-[var(--pyre-creme)]/10 px-2 py-3">
+      <p className="font-mono-bold text-2xl">{value}</p>
+      <p className="text-xs opacity-70 mt-0.5">{label}</p>
+    </div>
+  );
+}

--- a/apps/landing-page/src/hooks/useReferral.ts
+++ b/apps/landing-page/src/hooks/useReferral.ts
@@ -1,0 +1,51 @@
+// Fetches the logged-in member's referral code + stats from
+// /api/member/referral (which get-or-creates it via the integrations service).
+
+import { useEffect, useState } from 'react';
+
+export interface ReferralStats {
+  clicks: number;
+  redemptions: number;
+  conversions: number;
+  rewardsEarned: number;
+  rewardsActive: number;
+}
+
+export interface ReferralInfo {
+  code: string;
+  url: string;
+  discountPercent: number;
+  enabled: boolean;
+  stats: ReferralStats;
+}
+
+export function useReferral() {
+  const [referral, setReferral] = useState<ReferralInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const response = await fetch('/api/member/referral');
+        const data = await response.json().catch(() => ({}));
+        if (cancelled) return;
+        if (response.ok && data.referral) {
+          setReferral(data.referral as ReferralInfo);
+        } else {
+          setError(typeof data.error === 'string' ? data.error : 'unavailable');
+        }
+      } catch {
+        if (!cancelled) setError('unavailable');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { referral, loading, error };
+}

--- a/apps/landing-page/src/lib/account-config.ts
+++ b/apps/landing-page/src/lib/account-config.ts
@@ -50,6 +50,26 @@ export const accountConfig = {
       missed: 'Missed',
     },
   },
+  referral: {
+    title: 'Give 15%, Get a Discount',
+    subtitle:
+      'Share your personal link. Friends get a discount on their first session — and when they book, you get a discount on your next one.',
+    codeLabel: 'Your code',
+    linkLabel: 'Your link',
+    copyButton: 'Copy link',
+    copiedLabel: 'Copied!',
+    shareButton: 'Share',
+    shareText: (url: string, percent: number) =>
+      `Come sweat with me at Pyre — this link gets you ${percent}% off your first sauna + cold plunge session: ${url}`,
+    stats: {
+      clicksLabel: 'Link opens',
+      redemptionsLabel: 'Claimed',
+      conversionsLabel: 'Booked',
+    },
+    rewardActiveBadge: 'Reward active — discount on your next session',
+    errorState: 'Could not load your referral code. Please try again later.',
+    disabledState: 'Your referral code is currently inactive.',
+  },
   membership: {
     title: 'Membership',
     emptyState: 'No active membership',

--- a/apps/landing-page/src/lib/referral.ts
+++ b/apps/landing-page/src/lib/referral.ts
@@ -1,0 +1,113 @@
+// Copy for the referral landing page (/r/{code}) and its redemption form.
+// The referrer's name and discount percent are interpolated at render time —
+// {name} and {percent} placeholders in the strings below.
+
+export interface ReferralFormCopy {
+  firstNameLabel: string;
+  firstNamePlaceholder: string;
+  lastNameLabel: string;
+  lastNamePlaceholder: string;
+  emailLabel: string;
+  emailPlaceholder: string;
+  emailHelp: string;
+  submitLabel: string;
+  submittingLabel: string;
+  successTitle: string;
+  successMessage: string;
+  errorMessage: string;
+  /** Keyed on the relay's result codes for policy rejections. */
+  rejections: {
+    'already-redeemed': string;
+    'existing-customer': string;
+    'self-referral': string;
+    'referrer-disabled': string;
+    'unknown-code': string;
+  };
+}
+
+export interface ReferralStep {
+  title: string;
+  description: string;
+}
+
+export interface ReferralPageContent {
+  posthogSource: string;
+  hero: {
+    /** {name} and {percent} interpolated. */
+    title: string;
+    subtitle: string;
+  };
+  claim: {
+    pillLabel: string;
+    title: string;
+    subtitle: string;
+  };
+  steps: ReferralStep[];
+  form: ReferralFormCopy;
+  disclaimer: string;
+}
+
+export function interpolate(template: string, values: { name?: string; percent?: number }): string {
+  return template
+    .split('{name}')
+    .join(values.name ?? '')
+    .split('{percent}')
+    .join(values.percent != null ? String(values.percent) : '');
+}
+
+const referral: ReferralPageContent = {
+  posthogSource: 'referral',
+  hero: {
+    title: '{name} gave you {percent}% off',
+    subtitle:
+      "Pyre is Richmond's social sauna + cold plunge. Claim your discount and your first session is {percent}% off — no code needed at checkout.",
+  },
+  claim: {
+    pillLabel: 'A gift from {name}',
+    title: 'Claim your {percent}% off',
+    subtitle: 'First time at Pyre? Tell us where to put the discount and it applies automatically.',
+  },
+  steps: [
+    {
+      title: 'Tell us who you are',
+      description: 'Your name and the email you’ll book with. Takes 10 seconds.',
+    },
+    {
+      title: 'The discount attaches to your account',
+      description: 'Instantly — we’ll email you a booking link the moment it’s live.',
+    },
+    {
+      title: '{percent}% comes off automatically',
+      description: 'On your first session, at checkout. No code needed.',
+    },
+  ],
+  form: {
+    firstNameLabel: 'First name',
+    firstNamePlaceholder: 'First name',
+    lastNameLabel: 'Last name',
+    lastNamePlaceholder: 'Last name',
+    emailLabel: 'The email you’ll book with',
+    emailPlaceholder: 'you@example.com',
+    emailHelp: 'Your discount attaches to this email — book with it and {percent}% comes off.',
+    submitLabel: 'Claim my discount',
+    submittingLabel: 'Claiming…',
+    successTitle: 'You’re in!',
+    successMessage:
+      'Your discount is live. Check your inbox for a booking link — or book right away and {percent}% comes off at checkout.',
+    errorMessage: 'Something went wrong. Please try again.',
+    rejections: {
+      'already-redeemed':
+        'Looks like you’ve already claimed a referral discount — check your inbox for your booking link.',
+      'existing-customer':
+        'Referral discounts are for first-time guests, and it looks like you’ve been to Pyre before. We love that! Check your account for member perks instead.',
+      'self-referral':
+        'Nice try — you can’t refer yourself. Share your link with a friend instead!',
+      'referrer-disabled': 'This referral link is no longer active.',
+      'unknown-code': 'This referral link looks broken — ask your friend to re-send it.',
+    },
+  },
+  disclaimer:
+    'Referral discount valid for first-time Pyre guests on their first session booking. One referral discount per person. Applied automatically at checkout when you book with the email you claimed with.',
+};
+
+export default referral;

--- a/apps/landing-page/src/pages/api/member/referral.ts
+++ b/apps/landing-page/src/pages/api/member/referral.ts
@@ -1,0 +1,52 @@
+// Member referral endpoint: the logged-in member's personal referral code,
+// link, and stats. Auth is the Momence OAuth session; the data comes from the
+// integrations service (get-or-create, so first visit mints the code).
+
+import type { APIRoute } from 'astro';
+import { validateSession } from '@/lib/auth-session';
+
+export const prerender = false;
+
+function json(status: number, body: Record<string, unknown>): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', 'Cache-Control': 'private, no-cache' },
+  });
+}
+
+export const GET: APIRoute = async ({ cookies }) => {
+  const { session } = await validateSession(cookies);
+  if (!session.isAuthenticated || !session.user?.email) {
+    return json(401, { error: 'not_authenticated', referral: null });
+  }
+
+  const integrationsUrl = import.meta.env.INTEGRATIONS_API_URL ?? process.env.INTEGRATIONS_API_URL;
+  const apiSecret = import.meta.env.REFERRAL_API_SECRET ?? process.env.REFERRAL_API_SECRET;
+  if (!integrationsUrl || !apiSecret) {
+    console.error('[Referral] INTEGRATIONS_API_URL / REFERRAL_API_SECRET not configured');
+    return json(503, { error: 'unavailable', referral: null });
+  }
+
+  try {
+    const response = await fetch(`${integrationsUrl}/api/referral/me`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiSecret}`,
+      },
+      body: JSON.stringify({
+        email: session.user.email,
+        firstName: session.user.firstName,
+      }),
+    });
+    if (!response.ok) {
+      console.error(`[Referral] Integrations /me failed: ${response.status}`);
+      return json(response.status === 404 ? 404 : 502, { error: 'unavailable', referral: null });
+    }
+    const referral = await response.json();
+    return json(200, { referral });
+  } catch (error) {
+    console.error('[Referral] Integrations /me errored', error);
+    return json(502, { error: 'unavailable', referral: null });
+  }
+};

--- a/apps/landing-page/src/pages/api/referral-redemption.ts
+++ b/apps/landing-page/src/pages/api/referral-redemption.ts
@@ -1,0 +1,145 @@
+import { getRedis } from '@pyre/webhook-core';
+import type { APIRoute } from 'astro';
+import signupForm from '../../lib/signupForm';
+import { verifyTurnstileToken } from '../../lib/turnstile';
+
+export const prerender = false;
+
+// Referral redemption intake. Same division of labor as the partner
+// verification relay: this route owns the abuse checks (Turnstile, honeypots,
+// timing, rate limits), then hands off server-to-server to the integrations
+// service, which owns the Momence and email credentials. Browsers never call
+// integrations directly, so no CORS.
+
+const MAX_NAME_LENGTH = 120;
+const MAX_EMAIL_LENGTH = 254;
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const CODE_RE = /^[A-Za-z0-9]{3,16}$/;
+
+const IP_LIMIT = 20; // per hour
+const EMAIL_LIMIT = 3; // per day
+
+function json(status: number, body: Record<string, unknown>): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+/** true = over the limit. Fails open when Redis is unconfigured. */
+async function isRateLimited(key: string, limit: number, windowSeconds: number): Promise<boolean> {
+  const redis = getRedis();
+  if (!redis) return false;
+  try {
+    const count = await redis.incr(key);
+    if (count === 1) await redis.expire(key, windowSeconds);
+    return count > limit;
+  } catch {
+    return false;
+  }
+}
+
+export const POST: APIRoute = async ({ request, clientAddress }) => {
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return json(400, { ok: false, error: 'Invalid request' });
+  }
+
+  const code = typeof body.code === 'string' ? body.code.trim() : '';
+  const firstName = typeof body.firstName === 'string' ? body.firstName.trim() : '';
+  const lastName = typeof body.lastName === 'string' ? body.lastName.trim() : '';
+  const email = typeof body.email === 'string' ? body.email.trim().toLowerCase() : '';
+  const turnstileToken = typeof body.turnstileToken === 'string' ? body.turnstileToken : '';
+
+  // Honeypots + minimum fill time re-checked server-side; silent 200 so bots
+  // learn nothing.
+  const { honeypotFields, timestampField, minSubmissionTime } = signupForm.antiSpam;
+  const honeypotTripped = [honeypotFields.website, honeypotFields.confirmEmail].some(
+    (field) => typeof body[field] === 'string' && (body[field] as string).trim() !== ''
+  );
+  const startedAt = Number(body[timestampField]);
+  const tooFast =
+    !Number.isFinite(startedAt) || (Date.now() - startedAt) / 1000 < minSubmissionTime;
+  if (honeypotTripped || tooFast) {
+    return json(200, { ok: true, result: 'redeemed' });
+  }
+
+  if (!CODE_RE.test(code)) {
+    return json(400, { ok: false, error: 'This referral link looks broken.' });
+  }
+  if (!firstName || firstName.length > MAX_NAME_LENGTH) {
+    return json(400, { ok: false, error: 'Please enter your first name.' });
+  }
+  if (!lastName || lastName.length > MAX_NAME_LENGTH) {
+    return json(400, { ok: false, error: 'Please enter your last name.' });
+  }
+  if (!EMAIL_RE.test(email) || email.length > MAX_EMAIL_LENGTH) {
+    return json(400, { ok: false, error: 'Please enter a valid email.' });
+  }
+
+  if (!turnstileToken || !(await verifyTurnstileToken(turnstileToken))) {
+    return json(400, { ok: false, error: 'Security check failed. Please try again.' });
+  }
+
+  const ip = clientAddress ?? request.headers.get('x-forwarded-for')?.split(',')[0] ?? 'unknown';
+  const ipKey = `referral:rl:ip:${ip}`;
+  const emailKey = `referral:rl:email:${email}`;
+  if (
+    (await isRateLimited(ipKey, IP_LIMIT, 60 * 60)) ||
+    (await isRateLimited(emailKey, EMAIL_LIMIT, 24 * 60 * 60))
+  ) {
+    return json(429, { ok: false, error: 'Too many requests — please try again later.' });
+  }
+
+  // A failure on our side shouldn't burn the caller's quota.
+  const refundRateLimit = async () => {
+    const redis = getRedis();
+    if (!redis) return;
+    try {
+      await redis.decr(ipKey);
+      await redis.decr(emailKey);
+    } catch {
+      // best-effort
+    }
+  };
+
+  const integrationsUrl = import.meta.env.INTEGRATIONS_API_URL ?? process.env.INTEGRATIONS_API_URL;
+  const apiSecret = import.meta.env.REFERRAL_API_SECRET ?? process.env.REFERRAL_API_SECRET;
+  if (!integrationsUrl || !apiSecret) {
+    console.error('[Referral] INTEGRATIONS_API_URL / REFERRAL_API_SECRET not configured');
+    await refundRateLimit();
+    return json(503, { ok: false, error: 'Redemption is temporarily unavailable.' });
+  }
+
+  try {
+    const response = await fetch(`${integrationsUrl}/api/referral/redeem`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiSecret}`,
+      },
+      body: JSON.stringify({ code, firstName, lastName, email }),
+    });
+    const result = (await response.json().catch(() => ({}))) as { result?: string };
+
+    if (response.ok) {
+      // 'redeemed' or 'already-redeemed' — both end states the form explains.
+      return json(200, { ok: true, result: result.result ?? 'redeemed' });
+    }
+    if (response.status === 409 || response.status === 400) {
+      // Policy rejections ('existing-customer', 'self-referral', ...) pass
+      // through as result codes so the form shows the right copy.
+      return json(200, { ok: false, result: result.result ?? 'rejected' });
+    }
+
+    console.error(`[Referral] Integrations request failed: ${response.status}`);
+    await refundRateLimit();
+    return json(502, { ok: false, error: 'Something went wrong. Please try again later.' });
+  } catch (error) {
+    console.error('[Referral] Integrations request errored', error);
+    await refundRateLimit();
+    return json(502, { ok: false, error: 'Something went wrong. Please try again later.' });
+  }
+};

--- a/apps/landing-page/src/pages/r/[code].astro
+++ b/apps/landing-page/src/pages/r/[code].astro
@@ -1,0 +1,149 @@
+---
+import { getRedis } from '@pyre/webhook-core';
+import { Image } from 'astro:assets';
+import warmSaunaImg from '../../assets/images/warm_sauna.webp';
+import ReferralRedeemForm from '../../components/ReferralRedeemForm.astro';
+import Layout from '../../layouts/main.astro';
+import referral, { interpolate } from '../../lib/referral';
+
+export const prerender = false;
+
+// Personalized referral landing page: pyresauna.com/r/{CODE}. The referrer's
+// name and discount render server-side (fetched from the integrations service
+// — codes aren't enumerable client-side), and the form claims the discount on
+// the spot. Unknown or disabled codes bounce home rather than 404 so a dead
+// link still lands somewhere useful.
+
+const rawCode = Astro.params.code ?? '';
+
+interface ReferralLookup {
+  code: string;
+  displayName: string;
+  discountPercent: number;
+  referrerType: 'member' | 'partner';
+}
+
+async function lookupCode(code: string): Promise<ReferralLookup | null> {
+  if (!/^[A-Za-z0-9]{3,16}$/.test(code)) return null;
+  const integrationsUrl = import.meta.env.INTEGRATIONS_API_URL ?? process.env.INTEGRATIONS_API_URL;
+  const apiSecret = import.meta.env.REFERRAL_API_SECRET ?? process.env.REFERRAL_API_SECRET;
+  if (!integrationsUrl || !apiSecret) {
+    console.error('[Referral] INTEGRATIONS_API_URL / REFERRAL_API_SECRET not configured');
+    return null;
+  }
+  try {
+    const response = await fetch(
+      `${integrationsUrl}/api/referral/lookup?code=${encodeURIComponent(code)}`,
+      { headers: { Authorization: `Bearer ${apiSecret}` } }
+    );
+    if (!response.ok) return null;
+    return (await response.json()) as ReferralLookup;
+  } catch (error) {
+    console.error('[Referral] Lookup failed', error);
+    return null;
+  }
+}
+
+const lookup = await lookupCode(rawCode);
+if (!lookup) {
+  return Astro.redirect('/', 302);
+}
+
+// Click counter feeds the referrer's /account stats. Best-effort; PostHog gets
+// its own referral_link_clicked event client-side for funnel analysis.
+try {
+  await getRedis()?.incr(`referral:clicks:${lookup.code}`);
+} catch {
+  // A lost click count must never break the page.
+}
+
+const vars = { name: lookup.displayName, percent: lookup.discountPercent };
+const pageTitle = `${lookup.displayName} gave you ${lookup.discountPercent}% off | Pyre Sauna`;
+const pageDescription = interpolate(referral.hero.subtitle, vars);
+---
+
+<Layout
+  title={pageTitle}
+  description={pageDescription}
+  noIndex={true}
+  hidePromos={true}
+  transparentNav={true}
+  logoOnly={true}
+>
+  <div class="dark bg-[var(--pyre-black)] text-[var(--pyre-creme)]">
+    <section class="relative w-full min-h-dvh flex items-center justify-center overflow-hidden">
+      <Image
+        src={warmSaunaImg}
+        alt=""
+        widths={[768, 1280, 1920]}
+        sizes="100vw"
+        class="absolute inset-0 w-full h-full object-cover object-center"
+        loading="eager"
+        decoding="async"
+      />
+      <div class="absolute inset-0 bg-[var(--pyre-black)]/70"></div>
+      <div class="absolute inset-0 bg-gradient-to-t from-[var(--pyre-black)] via-[var(--pyre-black)]/40 to-[var(--pyre-black)]/60"></div>
+
+      <div class="relative z-10 max-w-2xl mx-auto px-4 pt-32 pb-16 md:pt-40 md:pb-24 text-center">
+        <p class="inline-block rounded-full border border-[var(--pyre-muted-gold)]/60 px-4 py-1.5 font-mono-bold text-xs uppercase tracking-wide text-[var(--pyre-muted-gold)] mb-6">
+          {interpolate(referral.claim.pillLabel, vars)}
+        </p>
+        <h1 class="font-primary-semibold text-[clamp(2.25rem,6vw,4rem)] tracking-[-0.02em] uppercase leading-[1.05] mb-4">
+          {interpolate(referral.hero.title, vars)}
+        </h1>
+        <p class="text-base md:text-lg opacity-80 max-w-xl mx-auto mb-10">
+          {interpolate(referral.hero.subtitle, vars)}
+        </p>
+
+        <div class="rounded-xl border border-[var(--pyre-creme)]/15 bg-[var(--pyre-black)]/60 backdrop-blur-sm p-6 md:p-8 text-left">
+          <h2 class="font-primary-semibold text-2xl uppercase tracking-[-0.01em] mb-1 text-center">
+            {interpolate(referral.claim.title, vars)}
+          </h2>
+          <p class="text-sm opacity-70 mb-6 text-center">{referral.claim.subtitle}</p>
+          <ReferralRedeemForm
+            code={lookup.code}
+            discountPercent={lookup.discountPercent}
+            copy={referral.form}
+          />
+        </div>
+
+        <ol class="grid grid-cols-1 sm:grid-cols-3 gap-6 mt-12 text-left">
+          {
+            referral.steps.map((step, index) => (
+              <li>
+                <p class="font-mono-bold text-xs uppercase tracking-wide text-[var(--pyre-muted-gold)] mb-1.5">
+                  {String(index + 1).padStart(2, '0')}
+                </p>
+                <p class="font-primary-semibold text-base mb-1">{interpolate(step.title, vars)}</p>
+                <p class="text-sm opacity-70">{interpolate(step.description, vars)}</p>
+              </li>
+            ))
+          }
+        </ol>
+
+        <p class="mt-12 text-xs opacity-50 max-w-lg mx-auto">{referral.disclaimer}</p>
+      </div>
+    </section>
+  </div>
+</Layout>
+
+<script is:inline define:vars={{ code: lookup.code, referrerType: lookup.referrerType }}>
+  const capture = () => {
+    if (window.posthog?.capture) {
+      window.posthog.capture('referral_link_clicked', {
+        code,
+        referrer_type: referrerType,
+      });
+      return true;
+    }
+    return false;
+  };
+  // PostHog loads async; retry briefly rather than racing it.
+  if (!capture()) {
+    let attempts = 0;
+    const timer = setInterval(() => {
+      attempts += 1;
+      if (capture() || attempts > 20) clearInterval(timer);
+    }, 250);
+  }
+</script>

--- a/apps/supabase/migrations/20260811130000_referrals.sql
+++ b/apps/supabase/migrations/20260811130000_referrals.sql
@@ -1,0 +1,196 @@
+-- Customer referral program (apps/integrations). Every referrer — an
+-- individual Momence member or a partner business — gets a personalized code
+-- (e.g. WES15) behind pyresauna.com/r/{code}. A friend who opens the link and
+-- submits their email is find-or-created in Momence and given the tier's
+-- customer tag; the manually-created tag-keyed Price Rule applies the discount
+-- at checkout, exactly like the partner program. Momence discount codes have
+-- no API (dashboard-only, not person-restrictable), which is why the code is
+-- Pyre-side and the discount vehicle is a tag.
+--
+-- Hard rule: first-time customers only. Redemption is rejected for anyone with
+-- booking history, and the first-booking check is re-verified at conversion
+-- time before any reward is granted.
+--
+-- Four tables:
+--   referral_tiers       percent -> Momence tag the Price Rule keys on
+--   referrers            one row + one code per referrer (member XOR partner)
+--   referral_redemptions the friend-side state machine (audit trail, no deletes)
+--   referral_rewards     the referrer-side reward ledger (double-sided program)
+
+-- Tier registry. Each row needs a matching Momence customer tag AND a Price
+-- Rule keyed on that tag, both created by hand in the Momence dashboard
+-- before the tier is usable (same operational contract as partners.tag_name).
+create table public.referral_tiers (
+  percent integer primary key check (percent > 0 and percent < 100),
+  -- Momence customer tag (matched case-insensitively) the Price Rule keys on
+  tag_name text not null unique check (btrim(tag_name) <> ''),
+  -- Off = no new referrers may be assigned this tier; existing referrers keep it
+  enabled boolean not null default true,
+  created_at timestamptz not null default now()
+);
+
+insert into public.referral_tiers (percent, tag_name) values (15, 'referral-15');
+
+alter table public.referral_tiers enable row level security;
+
+create policy "admins can select referral_tiers"
+  on public.referral_tiers for select
+  to authenticated
+  using (public.is_admin());
+
+-- One row per referrer; the personalized code lives here (one code per
+-- referrer in v1).
+create table public.referrers (
+  id uuid primary key default gen_random_uuid(),
+  referrer_type text not null check (referrer_type in ('member', 'partner')),
+  -- Member referrers: their Momence member id. Partner referrers: the
+  -- partners.slug — deliberately NOT a foreign key, matching the
+  -- partner_verifications convention (history outlives partner rows).
+  momence_member_id bigint unique,
+  partner_slug text unique,
+  check (
+    (referrer_type = 'member' and momence_member_id is not null and partner_slug is null)
+    or (referrer_type = 'partner' and partner_slug is not null and momence_member_id is null)
+  ),
+  -- Member referrers: their email, used for the self-referral check and the
+  -- reward email. Null for partners (their contacts live on the partners row).
+  email text check (email is null or email = lower(email)),
+  -- What the friend sees on the landing page: "Wes gave you 15% off" /
+  -- "BFT Carytown gave you 15% off"
+  display_name text not null check (btrim(display_name) <> ''),
+  -- The shareable code, uppercase, unique across all referrers. Generated as
+  -- FIRSTNAME + 2 digits for members; chosen by admins for partners.
+  code text not null unique
+    check (code = upper(code) and code ~ '^[A-Z0-9]{3,16}$'),
+  -- Which tier this referrer's friends get. FK so a tier can't be deleted out
+  -- from under its referrers.
+  discount_percent integer not null default 15
+    references public.referral_tiers (percent),
+  -- Off = the /r/{code} page 404s and redemption attempts are rejected.
+  -- Existing redemptions are unaffected.
+  enabled boolean not null default true,
+  notes text,
+  created_by text,
+  updated_by text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.referrers enable row level security;
+
+create policy "admins can select referrers"
+  on public.referrers for select
+  to authenticated
+  using (public.is_admin());
+
+create trigger referrers_set_updated_at
+  before update on public.referrers
+  for each row execute function public.set_updated_at();
+
+-- The friend-side state machine. Code/percent/tag are snapshotted at
+-- redemption time so history stays true when a referrer's tier changes later.
+--
+--   pending    row claimed, Momence member/tag write not yet confirmed
+--   redeemed   tag on the member, discount live, awaiting first booking
+--   converted  first booking completed (terminal happy path)
+--   expired    never booked within the window; tag removed by the sweep
+--   revoked    pulled by an admin, or by the conversion path when the
+--              first-booking re-check failed (revoke_reason = 'not-first-time')
+create table public.referral_redemptions (
+  id uuid primary key default gen_random_uuid(),
+  referrer_id uuid not null references public.referrers (id),
+  code text not null,
+  discount_percent integer not null,
+  tag_name text not null,
+  friend_first_name text not null check (btrim(friend_first_name) <> ''),
+  friend_last_name text not null check (btrim(friend_last_name) <> ''),
+  friend_email text not null check (friend_email = lower(friend_email)),
+  friend_momence_member_id bigint,
+  status text not null default 'pending'
+    check (status in ('pending', 'redeemed', 'converted', 'expired', 'revoked')),
+  -- When the tier tag actually came off the member in Momence. Null on a live
+  -- discount; also null when removal failed and needs the maintenance sweep.
+  discount_tag_removed_at timestamptz,
+  converted_session_id bigint,
+  converted_session_booking_id bigint,
+  converted_at timestamptz,
+  -- The converting booking was later cancelled. Surfaced in the admin queue
+  -- for a manual decision — no automatic clawback.
+  cancelled_at timestamptz,
+  revoked_at timestamptz,
+  revoke_reason text,
+  -- Who moved the row: null = system (webhook/redemption path), an email = an
+  -- admin, 'cron' = the maintenance sweep. Same convention as
+  -- partner_verifications.decided_by.
+  decided_by text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+-- One referral discount per friend, ever, across all referrers. Doubles as
+-- the concurrency guard on simultaneous submissions (insert races surface as
+-- 23505). Expired/revoked rows drop out so a friend whose discount lapsed
+-- unused could be re-referred by an admin decision.
+create unique index referral_redemptions_live_friend_idx
+  on public.referral_redemptions (friend_email)
+  where status in ('pending', 'redeemed', 'converted');
+
+-- The admin queue and the referrer's /account stats: newest first per referrer.
+create index referral_redemptions_referrer_idx
+  on public.referral_redemptions (referrer_id, created_at desc);
+
+-- The session-booked webhook lookup: is this member an awaiting-first-booking
+-- friend?
+create index referral_redemptions_active_member_idx
+  on public.referral_redemptions (friend_momence_member_id)
+  where status = 'redeemed';
+
+alter table public.referral_redemptions enable row level security;
+
+create policy "admins can select referral_redemptions"
+  on public.referral_redemptions for select
+  to authenticated
+  using (public.is_admin());
+
+create trigger referral_redemptions_set_updated_at
+  before update on public.referral_redemptions
+  for each row execute function public.set_updated_at();
+
+-- The referrer-side reward ledger (member referrers only in v1 — partner
+-- conversions are settled manually off the redemption counts).
+--
+--   granted   reward tag on the referrer, discount live for their next session
+--   consumed  their next booking arrived; tag removed
+--   expired   unused past the reward window; tag removed by the sweep
+--   revoked   pulled by an admin (e.g. the converting booking was cancelled)
+create table public.referral_rewards (
+  id uuid primary key default gen_random_uuid(),
+  referrer_id uuid not null references public.referrers (id),
+  -- One reward per conversion, enforced here — this is the idempotency guard
+  -- against webhook retries racing the reward grant.
+  redemption_id uuid not null unique references public.referral_redemptions (id),
+  reward_tag_name text not null,
+  status text not null default 'granted'
+    check (status in ('granted', 'consumed', 'expired', 'revoked')),
+  granted_at timestamptz not null default now(),
+  consumed_at timestamptz,
+  consumed_session_booking_id bigint,
+  reward_tag_removed_at timestamptz,
+  decided_by text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index referral_rewards_referrer_idx
+  on public.referral_rewards (referrer_id, granted_at desc);
+
+alter table public.referral_rewards enable row level security;
+
+create policy "admins can select referral_rewards"
+  on public.referral_rewards for select
+  to authenticated
+  using (public.is_admin());
+
+create trigger referral_rewards_set_updated_at
+  before update on public.referral_rewards
+  for each row execute function public.set_updated_at();


### PR DESCRIPTION
## What this is

A double-sided referral program: every customer (and partner business) gets a personalized code behind `pyresauna.com/r/{CODE}`. Friends who open the link and submit their email get a discount (15% default, configurable per referrer) on their **first session**, applied automatically at checkout via a Momence customer tag + tag-keyed price rule — the same mechanism as the BFT partner program, since Momence discount codes have no API. When the friend completes their first booking, the referrer earns a discount on their next session.

**First-time customers only, hard-gated:** anyone with prior booking history (including cancelled bookings) is rejected at redemption time, and the first-booking check is re-verified at conversion time before any reward is granted.

## How it works

- **`/r/{code}`** (landing page, SSR) renders "Wes gave you 15% off" server-side and claims the discount on the spot — Turnstile + honeypots + rate limits on the relay, same pattern as partner verification.
- **Redemption** find-or-creates the Momence member and assigns the tier tag. One referral discount per friend ever (partial unique index), no self-referrals.
- **Conversion** hooks the `session-booked` webhook: verifies first booking, removes the friend's tag (`DELETE /host/members/{id}/tags/{tagId}` — confirmed in the Momence OpenAPI schema), grants the referrer a reward tag + email. The reward is consumed on the referrer's next booking.
- **`referral-maintenance` cron** reconciles missed webhooks, expires unbooked redemptions (60d) and unused rewards (90d), retries failed tag removals, and cleans crashed pending rows. Honors `dryRun`.
- **`/account`** gets a referral card (code, copy/share link, stats); first visit silently mints the member's code.
- **`/admin/referrals`** manages tiers (with Momence tag health checks), referrers, the redemption queue, and the reward ledger, behind a new `referrals:manage` capability.
- Two transactional emails (`referral-redeemed`, `referral-reward-earned`), dark behind the email gate until enabled.

## Before this goes live

1. In Momence: create tags `referral-15` + `referral-reward` and a price rule keyed on each (session scope, matching the partner rule); verify checkout behavior and stacking with partner tags; then "Refresh Momence tags" on `/admin/referrals`.
2. Set `REFERRAL_API_SECRET` on both Vercel projects (optional: `REFERRAL_REWARD_TAG_NAME`, `REFERRAL_EXPIRY_DAYS`).
3. Apply the migration (`20260811130000_referrals.sql`).
4. Enable the two email templates from `/admin/email-templates`, then run an end-to-end test (redeem → tag lands → book → conversion + reward).

## Verification

- `type-check`, `biome check`, and production `build` pass for both apps (remaining lint warnings are pre-existing in `FirstTimerWelcome.tsx`).
- Smoke-tested on the dev server: `/r/{unknown}` 302s home; the redemption relay silently 200s bot-shaped submissions and 400s missing Turnstile.
- Tag assigns are idempotent and all status flips are conditional updates, so webhook retries and cron overlap are safe by construction.