### PR TITLE
Show campaign short links on the UTM Assist page

### DIFF
--- a/apps/integrations/src/components/admin/UtmAssist.tsx
+++ b/apps/integrations/src/components/admin/UtmAssist.tsx
@@ -279,6 +279,9 @@ interface SavedLink {
 interface CampaignWithLinks {
   campaign: SavedCampaign;
   links: SavedLink[];
+  // Short links whose destination carries this campaign's utm_campaign.
+  // Optional so an older payload without the field can't crash the island.
+  shortlinks?: ShortLinkRow[];
 }
 
 // One row of the "Recent short links" list (mirrors the server ShortLink shape,
@@ -1597,8 +1600,9 @@ export function UtmAssist({ origin, blogPosts }: UtmAssistProps) {
         )}
 
         <div className="space-y-2">
-          {campaigns?.map(({ campaign, links }) => {
+          {campaigns?.map(({ campaign, links, shortlinks }) => {
             const isOpen = expanded[campaign.id] ?? false;
+            const campaignShortlinks = shortlinks ?? [];
             return (
               <div key={campaign.id} className="rounded border border-white/10 bg-white/5">
                 <div className="flex items-center gap-2 px-3 py-2">
@@ -1615,6 +1619,12 @@ export function UtmAssist({ origin, blogPosts }: UtmAssistProps) {
                     <span className="text-xs text-white/40">
                       {links.length} link{links.length === 1 ? '' : 's'}
                     </span>
+                    {campaignShortlinks.length > 0 && (
+                      <span className="text-xs text-white/40">
+                        {campaignShortlinks.length} short link
+                        {campaignShortlinks.length === 1 ? '' : 's'}
+                      </span>
+                    )}
                   </button>
                   <button
                     type="button"
@@ -1730,6 +1740,45 @@ export function UtmAssist({ origin, blogPosts }: UtmAssistProps) {
                         </div>
                       );
                     })}
+                    {campaignShortlinks.length > 0 && (
+                      <div className="px-3 py-3">
+                        <p className="mb-2 text-xs font-mono-bold uppercase tracking-wide text-white/40">
+                          Short links
+                        </p>
+                        <ul className="flex flex-col gap-2">
+                          {campaignShortlinks.map((sl) => {
+                            const shortUrl = `${origin}/s/${sl.code}`;
+                            return (
+                              <li key={sl.code} className="flex items-center gap-3">
+                                <div className="min-w-0 flex-1">
+                                  <div className="flex items-center gap-2">
+                                    <span className="font-mono text-sm text-[var(--pyre-creme)] truncate">
+                                      /s/{sl.code}
+                                    </span>
+                                    {sl.label && (
+                                      <span className="text-xs text-white/40 truncate">
+                                        {sl.label}
+                                      </span>
+                                    )}
+                                  </div>
+                                  <p className="text-xs text-white/30 break-all">→ {sl.url}</p>
+                                </div>
+                                <span className="shrink-0 text-xs text-white/40">
+                                  {sl.clicks} click{sl.clicks === 1 ? '' : 's'}
+                                </span>
+                                <button
+                                  type="button"
+                                  onClick={() => copyRow(sl.code, shortUrl)}
+                                  className="shrink-0 px-2 py-1 rounded border border-white/20 text-xs text-white/60 hover:text-white hover:border-white/40 transition-colors"
+                                >
+                                  {copiedCode === sl.code ? 'Copied' : 'Copy'}
+                                </button>
+                              </li>
+                            );
+                          })}
+                        </ul>
+                      </div>
+                    )}
                   </div>
                 )}
               </div>

--- a/apps/integrations/src/pages/api/admin/campaign-performance.ts
+++ b/apps/integrations/src/pages/api/admin/campaign-performance.ts
@@ -12,6 +12,7 @@ import {
   listCampaignsWithLinks,
   listShortLinks,
   slugifyCampaign,
+  utmCampaignOfUrl,
 } from '@pyre/webhook-core';
 import type { APIRoute } from 'astro';
 import { isPostHogQueryConfigured, queryHogQL } from '@/lib/analytics/posthog-query';
@@ -55,15 +56,6 @@ interface PerformanceResponse {
   campaigns: CampaignRow[];
   unattributed: Array<{ slug: string; pageviews: number; visitors: number }>;
   posthog: { configured: boolean; missingEvents: string[]; error: string | null };
-}
-
-function utmCampaignOf(url: string): string | null {
-  try {
-    const raw = new URL(url).searchParams.get('utm_campaign');
-    return raw ? slugifyCampaign(raw) || null : null;
-  } catch {
-    return null;
-  }
 }
 
 async function buildReport(days: number): Promise<PerformanceResponse> {
@@ -171,7 +163,7 @@ async function buildReport(days: number): Promise<PerformanceResponse> {
     Array<{ code: string; label: string; clicks: number }>
   >();
   for (const link of shortlinkPage.links) {
-    const slug = utmCampaignOf(link.url);
+    const slug = utmCampaignOfUrl(link.url);
     if (!slug) continue;
     const list = shortlinksBySlug.get(slug) ?? [];
     list.push({ code: link.code, label: link.label, clicks: Number(link.clicks) || 0 });

--- a/apps/integrations/src/pages/api/admin/utm-campaigns.ts
+++ b/apps/integrations/src/pages/api/admin/utm-campaigns.ts
@@ -1,7 +1,12 @@
 // Shared UTM campaign list for the admin UTM Assist tool, ported from the
 // landing-page admin. Backed by the shared Upstash store in @pyre/webhook-core.
 
-import { deleteCampaign, listCampaignsWithLinks } from '@pyre/webhook-core';
+import {
+  deleteCampaign,
+  listCampaignsWithLinks,
+  listShortLinks,
+  utmCampaignOfUrl,
+} from '@pyre/webhook-core';
 import type { APIRoute } from 'astro';
 import { requirePage } from '@/lib/auth/admin';
 
@@ -16,7 +21,37 @@ export const GET: APIRoute = async ({ cookies }) => {
   if (gate instanceof Response) return gate;
 
   try {
-    const campaigns = await listCampaignsWithLinks();
+    // Short links carry no campaignId — like the campaign-performance report,
+    // they are joined by the utm_campaign baked into their destination URL.
+    // Links without a parseable utm_campaign are omitted, and the join covers
+    // the 500 newest short links (same cap the performance report uses).
+    const [campaignsWithLinks, shortlinkPage] = await Promise.all([
+      listCampaignsWithLinks(),
+      listShortLinks(500, 0),
+    ]);
+
+    const shortlinksBySlug = new Map<
+      string,
+      Array<{ code: string; url: string; label: string; clicks: number; createdAt: number }>
+    >();
+    for (const link of shortlinkPage.links) {
+      const slug = utmCampaignOfUrl(link.url);
+      if (!slug) continue;
+      const list = shortlinksBySlug.get(slug) ?? [];
+      list.push({
+        code: link.code,
+        url: link.url,
+        label: link.label,
+        clicks: Number(link.clicks) || 0,
+        createdAt: Number(link.createdAt) || 0,
+      });
+      shortlinksBySlug.set(slug, list);
+    }
+
+    const campaigns = campaignsWithLinks.map((entry) => ({
+      ...entry,
+      shortlinks: shortlinksBySlug.get(entry.campaign.slug.toLowerCase()) ?? [],
+    }));
     return json({ campaigns });
   } catch (err) {
     return json({ error: err instanceof Error ? err.message : 'Unknown error' }, 500);

--- a/packages/webhook-core/src/index.ts
+++ b/packages/webhook-core/src/index.ts
@@ -33,6 +33,7 @@ export {
   slugifyCampaign,
   updateLinkLabel,
   type UtmCampaign,
+  utmCampaignOfUrl,
   type UtmLink,
 } from './utm-campaign-store';
 export {

--- a/packages/webhook-core/src/utm-campaign-store.ts
+++ b/packages/webhook-core/src/utm-campaign-store.ts
@@ -53,6 +53,19 @@ export function slugifyCampaign(name: string): string {
     .replace(/^-+|-+$/g, '');
 }
 
+/**
+ * The campaign slug a URL is attributed to, via its utm_campaign param.
+ * Null for unparseable URLs or URLs without a utm_campaign.
+ */
+export function utmCampaignOfUrl(url: string): string | null {
+  try {
+    const raw = new URL(url).searchParams.get('utm_campaign');
+    return raw ? slugifyCampaign(raw) || null : null;
+  } catch {
+    return null;
+  }
+}
+
 async function getAllCampaigns(): Promise<UtmCampaign[]> {
   const redis = getRedis();
   if (!redis) return [];


### PR DESCRIPTION
## Summary

Each campaign in the UTM Assist accordion (`/admin/utm-assist`) now lists the short links associated with it, so existing short links can be found and reused instead of minting duplicates. Each row shows the `/s/<code>` short link, the destination URL it directs to, its click count, and a Copy button that puts the full short URL on the clipboard. Campaign headers also show a short-link count so reusable links are visible before expanding.

## Changes

- **`packages/webhook-core/src/utm-campaign-store.ts`**: new exported `utmCampaignOfUrl()` helper — the campaign slug a URL is attributed to via its `utm_campaign` param (extracted from a local copy in `campaign-performance.ts`, exported from the package index).
- **`apps/integrations/src/pages/api/admin/campaign-performance.ts`**: behavior-neutral refactor to use the shared helper, keeping both routes on identical join semantics.
- **`apps/integrations/src/pages/api/admin/utm-campaigns.ts`**: GET now fetches the 500 newest short links alongside campaigns and attaches a `shortlinks` array to each campaign, joined by the `utm_campaign` baked into each short link's destination URL (short links carry no `campaignId` — same implicit join the campaign performance report uses). Additive response change; DELETE and existing consumers unaffected.
- **`apps/integrations/src/components/admin/UtmAssist.tsx`**: renders the "Short links" subsection inside each expanded campaign, reusing the existing `copyRow`/`copiedCode` clipboard handling and the page's styling conventions. The `shortlinks` field is optional on the client type so an older payload can't crash the island.

Short links whose destination has no parseable `utm_campaign` are omitted (same limitation the performance report has). Campaigns with no matching short links render exactly as before.

Scope: `apps/integrations` only — the legacy `apps/landing-page` copy of the page is untouched.

## Testing

- `yarn type-check` passes (`@pyre/integrations`, `@pyre/landing-page`, `@pyre/social`).
- Biome check clean on all changed files; the only workspace lint error (`src/assets/pyre_logo.svg` a11y) is pre-existing and unrelated.
- Manual verification requires `KV_REST_API_URL`/`KV_REST_API_TOKEN`: expand a campaign on `/admin/utm-assist` whose slug matches a short link's destination `utm_campaign` and confirm the short link row, destination URL, clicks, and Copy behavior; spot-check `/api/admin/utm-campaigns` JSON for the `shortlinks` arrays; confirm `/admin/campaigns` still renders after the helper refactor.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFeXktBzbDZi5DfFX41rge)_