### PR TITLE
Resolve referral members by Momence member id, not email search

### DIFF
--- a/apps/integrations/src/pages/api/referral/me.ts
+++ b/apps/integrations/src/pages/api/referral/me.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro';
 import { getDb } from '@/lib/db';
-import { findMemberByEmail } from '@/lib/momence/host-api';
+import { fetchHostMember, findMemberByEmail, type HostMember } from '@/lib/momence/host-api';
 import { isReferralAuthorized } from '@/lib/referral/api-auth';
 import { getReferralClicks } from '@/lib/referral/codes';
 import { getOrCreateMemberReferrer } from '@/lib/referral/referrers';
@@ -40,10 +40,25 @@ export const POST: APIRoute = async ({ request }) => {
 
   const email = typeof body.email === 'string' ? body.email.trim().toLowerCase() : '';
   const firstName = typeof body.firstName === 'string' ? body.firstName.trim() : '';
+  const momenceMemberId =
+    typeof body.momenceMemberId === 'number' && Number.isFinite(body.momenceMemberId)
+      ? body.momenceMemberId
+      : null;
   if (!EMAIL_RE.test(email)) return json(400, { error: 'Invalid email' });
 
   try {
-    const member = await findMemberByEmail(email);
+    // The OAuth profile's host member id is authoritative when the caller has
+    // it; the email search is a fuzzy first-page match and can miss members
+    // (it did for staff addresses), so it's only the fallback.
+    let member: HostMember | null = null;
+    if (momenceMemberId !== null) {
+      try {
+        member = await fetchHostMember(momenceMemberId);
+      } catch {
+        member = null;
+      }
+    }
+    if (!member) member = await findMemberByEmail(email);
     if (!member) return json(404, { error: 'member-not-found' });
 
     const result = await getOrCreateMemberReferrer({

--- a/apps/landing-page/src/lib/momence-oauth-types.ts
+++ b/apps/landing-page/src/lib/momence-oauth-types.ts
@@ -27,6 +27,11 @@ export interface MomenceTokenData {
  */
 export interface MomenceUserProfile {
   id: number;
+  /**
+   * Momence host member id (nullable in AuthProfileDto). Distinct from `id`
+   * (the OAuth user id) — host-API calls and webhooks key on THIS id.
+   */
+  memberId?: number | null;
   email: string;
   firstName: string;
   lastName: string;

--- a/apps/landing-page/src/lib/momence-oauth.ts
+++ b/apps/landing-page/src/lib/momence-oauth.ts
@@ -235,6 +235,7 @@ export async function fetchUserProfile(accessToken: string): Promise<MomenceUser
 
   return {
     id: data.userId,
+    memberId: typeof data.memberId === 'number' ? data.memberId : null,
     email: data.email || '',
     firstName: data.firstName || 'User',
     lastName: data.lastName || '',

--- a/apps/landing-page/src/pages/api/member/referral.ts
+++ b/apps/landing-page/src/pages/api/member/referral.ts
@@ -37,6 +37,9 @@ export const GET: APIRoute = async ({ cookies }) => {
       body: JSON.stringify({
         email: session.user.email,
         firstName: session.user.firstName,
+        // Host member id from the OAuth profile — lets integrations fetch the
+        // member directly instead of relying on the fuzzy email search.
+        momenceMemberId: session.user.memberId ?? undefined,
       }),
     });
     if (!response.ok) {


### PR DESCRIPTION
Fixes the `member-not-found` 404 on `/api/member/referral` (the /account referral card).

**Root cause:** integrations resolved the logged-in member with `findMemberByEmail`, which wraps Momence's fuzzy first-page member search — and it misses members (it missed wes@pyresauna.com). The Momence OAuth profile already returns the authoritative host `memberId`, but our profile mapping discarded it.

**Fix:**
- `MomenceUserProfile` now carries `memberId` (mapped from `AuthProfileDto.memberId`, nullable).
- The `/api/member/referral` relay passes `momenceMemberId` to integrations.
- Integrations `/api/referral/me` fetches the member directly by id (`GET /host/members/{id}`), keeping the email search as fallback when the id is absent or the fetch fails.

Verified with `type-check` on both apps (0 errors). Merge + deploy, then reload /account.