### PR TITLE
Branch referral rewards by what the referrer buys

### DIFF
--- a/apps/integrations/src/components/admin/ReferralsManager.tsx
+++ b/apps/integrations/src/components/admin/ReferralsManager.tsx
@@ -582,11 +582,28 @@ function RewardsSection({
                 {referrer?.display_name ?? row.referrer_id}
               </span>
               {referrer && <span className="font-mono text-xs text-white/40">{referrer.code}</span>}
+              <span className="font-mono text-xs text-white/50">
+                {row.reward_type === 'credit'
+                  ? 'free credit'
+                  : row.reward_type === 'manual'
+                    ? 'front-desk comp'
+                    : 'next-session discount'}
+              </span>
               <span className="ml-auto font-mono text-xs text-white/30">
                 granted {fmtDate(row.granted_at)}
                 {row.consumed_at && ` → used ${fmtDate(row.consumed_at)}`}
               </span>
-              {canManage && row.status === 'granted' && (
+              {canManage && row.status === 'granted' && row.reward_type === 'manual' && (
+                <button
+                  type="button"
+                  className={buttonClass}
+                  disabled={busy}
+                  onClick={() => act({ action: 'fulfill-reward', id: row.id }, 'Comp fulfilled')}
+                >
+                  Mark fulfilled
+                </button>
+              )}
+              {canManage && row.status === 'granted' && row.reward_type !== 'credit' && (
                 <button
                   type="button"
                   className={buttonClass}

--- a/apps/integrations/src/emails/templates/ReferralRewardEarned.tsx
+++ b/apps/integrations/src/emails/templates/ReferralRewardEarned.tsx
@@ -2,26 +2,43 @@ import { Button, Text } from '@react-email/components';
 import { button, EmailLayout, heading, text } from '../components/EmailLayout';
 import type { ReferralRewardEarnedProps } from '../types';
 
-// To the referrer when a friend they referred completes their first booking:
-// their thank-you discount is live for their next session.
+// To the referrer when a friend they referred completes their first booking.
+// The reward copy matches how it was delivered: a free session credit already
+// on their account, a front-desk comp (members with no credit pack), or the
+// automatic next-session discount (drop-in payers).
+
+const REWARD_COPY: Record<ReferralRewardEarnedProps['rewardKind'], { body: string; cta: string }> =
+  {
+    credit: {
+      body: "As a thank-you, we've added a free session credit to your account — it's already there, ready to book with.",
+      cta: 'Book your free session',
+    },
+    manual: {
+      body: 'As a thank-you, your next session is on us — just mention your referral reward at the front desk next time you\u2019re in.',
+      cta: 'See the schedule',
+    },
+    discount: {
+      body: 'As a thank-you, a discount on your next session is now live on your account. Book with this email address and it comes off automatically at checkout — no code needed.',
+      cta: 'Book your next session',
+    },
+  };
 
 export function ReferralRewardEarned({
   firstName,
   friendFirstName,
+  rewardKind,
   bookUrl,
 }: ReferralRewardEarnedProps) {
+  const copy = REWARD_COPY[rewardKind];
   return (
     <EmailLayout preview="Your referral reward at Pyre is live" background="trees">
       <Text style={heading}>Nice one, {firstName}</Text>
       <Text style={text}>
-        {friendFirstName} just booked their first session at Pyre — thanks to you. As a thank-you, a
-        discount on your next session is now live on your account.
+        {friendFirstName} just booked their first session at Pyre — thanks to you.
       </Text>
-      <Text style={text}>
-        Book with this email address and it comes off automatically at checkout. No code needed.
-      </Text>
+      <Text style={text}>{copy.body}</Text>
       <Button href={bookUrl} style={button}>
-        Book your next session
+        {copy.cta}
       </Button>
       <Text style={text}>Keep them coming. Wes + Julien</Text>
     </EmailLayout>
@@ -31,6 +48,7 @@ export function ReferralRewardEarned({
 ReferralRewardEarned.PreviewProps = {
   firstName: 'Wes',
   friendFirstName: 'Jane',
+  rewardKind: 'credit',
   bookUrl: 'https://pyresauna.com/events?utm_source=referral-reward&utm_medium=referral',
 } satisfies ReferralRewardEarnedProps;
 

--- a/apps/integrations/src/emails/types.ts
+++ b/apps/integrations/src/emails/types.ts
@@ -119,6 +119,12 @@ export interface ReferralRedeemedProps {
 export interface ReferralRewardEarnedProps {
   firstName: string;
   friendFirstName: string;
+  /**
+   * How the reward was delivered: 'credit' = free session credit already on
+   * the account, 'manual' = comp fulfilled at the front desk, 'discount' =
+   * automatic % off the next session.
+   */
+  rewardKind: 'discount' | 'credit' | 'manual';
   bookUrl: string;
 }
 

--- a/apps/integrations/src/lib/db.ts
+++ b/apps/integrations/src/lib/db.ts
@@ -137,6 +137,14 @@ export interface ReferralRewardRow {
   id: string;
   referrer_id: string;
   redemption_id: string;
+  /**
+   * How the reward was delivered: 'credit' = event credit added to a pack
+   * (instant, lands consumed), 'manual' = staff-fulfilled comp, 'discount' =
+   * the original tag + price rule.
+   */
+  reward_type: 'discount' | 'credit' | 'manual';
+  credit_bought_membership_id: number | null;
+  credits_granted: number | null;
   reward_tag_name: string;
   status: 'granted' | 'consumed' | 'expired' | 'revoked';
   granted_at: string;

--- a/apps/integrations/src/lib/momence/host-api.ts
+++ b/apps/integrations/src/lib/momence/host-api.ts
@@ -236,6 +236,34 @@ export async function fetchMemberActivePacks(
   return packs;
 }
 
+export async function invalidateMemberPacksCache(memberId: number): Promise<void> {
+  const redis = getRedis();
+  if (redis) await redis.del(`${PACKS_CACHE_PREFIX}${memberId}`);
+}
+
+/**
+ * Set the remaining event credits on a package-events bought membership
+ * (ApiV2HostMembersBoughtMembershipsController_updateClassCredits). The
+ * endpoint SETS the count — no increment op exists — so callers read a fresh
+ * count first, and a booking landing inside the read-then-write window would
+ * be clobbered. Acceptable at Pyre's volume; keep grants rare and small.
+ */
+export async function updateBoughtMembershipEventCredits(
+  memberId: number,
+  boughtMembershipId: number,
+  eventCreditsLeft: number
+): Promise<{ eventCreditsLeft?: number }> {
+  const result = await momenceRequest<{ eventCreditsLeft?: number }>(
+    'PUT',
+    `/host/members/${memberId}/bought-memberships/${boughtMembershipId}/credits`,
+    { body: { eventCreditsLeft } }
+  );
+  // The 20h pack cache would otherwise serve the stale count to the credit
+  // reminder sweeps until tomorrow.
+  await invalidateMemberPacksCache(memberId);
+  return result;
+}
+
 // --- Sales (experimental endpoint — the purchase-trigger source) ---
 
 export type SaleItemType =

--- a/apps/integrations/src/lib/referral/admin-actions.ts
+++ b/apps/integrations/src/lib/referral/admin-actions.ts
@@ -81,6 +81,9 @@ export async function revokeReward(id: string, actorEmail: string): Promise<Revo
     .maybeSingle<ReferralRewardRow>();
   if (!row) return { outcome: 'not-found' };
   if (row.status !== 'granted') return { outcome: 'not-revocable', status: row.status };
+  // Credit rewards are already delivered — pulling the credit back is a
+  // dashboard decision, not a one-click revoke.
+  if (row.reward_type === 'credit') return { outcome: 'not-revocable', status: 'delivered' };
 
   const { data: referrer } = await db
     .from('referrers')
@@ -88,8 +91,9 @@ export async function revokeReward(id: string, actorEmail: string): Promise<Revo
     .eq('id', row.referrer_id)
     .maybeSingle<{ momence_member_id: number | null; email: string | null; code: string }>();
 
+  // Only discount rewards have a tag to pull; manual comps are just status.
   let tagRemoved = false;
-  if (referrer?.momence_member_id) {
+  if (row.reward_type === 'discount' && referrer?.momence_member_id) {
     try {
       const tagId = await getTagIdByName(row.reward_tag_name);
       if (tagId !== null) {
@@ -118,5 +122,37 @@ export async function revokeReward(id: string, actorEmail: string): Promise<Revo
     event: 'referral_reward_revoked',
     properties: { code: referrer?.code },
   });
+  return { outcome: 'revoked' };
+}
+
+/**
+ * Staff delivered a manual comp (e.g. an unlimited member's free session) —
+ * close the ledger row out.
+ */
+export async function fulfillReward(id: string, actorEmail: string): Promise<RevokeResult> {
+  const db = getDb();
+  if (!db) throw new Error('Supabase not configured');
+
+  const { data: row } = await db
+    .from('referral_rewards')
+    .select('*')
+    .eq('id', id)
+    .maybeSingle<ReferralRewardRow>();
+  if (!row) return { outcome: 'not-found' };
+  if (row.status !== 'granted' || row.reward_type !== 'manual') {
+    return { outcome: 'not-revocable', status: row.status };
+  }
+
+  const { data: updated } = await db
+    .from('referral_rewards')
+    .update({
+      status: 'consumed',
+      consumed_at: new Date().toISOString(),
+      decided_by: actorEmail,
+    })
+    .eq('id', id)
+    .eq('status', 'granted')
+    .select('id');
+  if (!updated || updated.length === 0) return { outcome: 'not-revocable', status: row.status };
   return { outcome: 'revoked' };
 }

--- a/apps/integrations/src/lib/referral/conversion.ts
+++ b/apps/integrations/src/lib/referral/conversion.ts
@@ -8,7 +8,14 @@ import { createWebhookLogger } from '@pyre/webhook-core';
 import { captureEvent } from '@/lib/analytics/posthog';
 import { getDb, type ReferralRedemptionRow, type ReferrerRow } from '@/lib/db';
 import { sendTemplate } from '@/lib/email/send';
-import { assignMemberTag, getTagIdByName, removeMemberTag } from '@/lib/momence/host-api';
+import {
+  assignMemberTag,
+  type BoughtMembership,
+  fetchMemberActivePacks,
+  getTagIdByName,
+  removeMemberTag,
+  updateBoughtMembershipEventCredits,
+} from '@/lib/momence/host-api';
 import { isMemberFirstBooking } from '@/lib/webhooks/momence';
 import { getReferrer, getReferrerByMemberId, getRewardTagName } from './registry';
 
@@ -46,10 +53,33 @@ async function removeDiscountTag(redemption: ReferralRedemptionRow): Promise<boo
   }
 }
 
+/** Prefer the pack with the most runway: no expiry first, then latest endDate. */
+function pickCreditPack(packs: BoughtMembership[]): BoughtMembership | null {
+  const eligible = packs.filter((p) => p.type === 'package-events');
+  if (eligible.length === 0) return null;
+  return eligible.sort((a, b) => {
+    if (a.endDate === null || b.endDate === null) {
+      return a.endDate === b.endDate ? 0 : a.endDate === null ? -1 : 1;
+    }
+    return new Date(b.endDate).getTime() - new Date(a.endDate).getTime();
+  })[0];
+}
+
+const SUBSCRIPTION_TYPES = new Set(['subscription', 'on-demand-subscription', 'patron']);
+
+type RewardKind = 'discount' | 'credit' | 'manual';
+
 /**
- * Grant the referrer their reward: ledger row (the idempotency claim), reward
- * tag, email. Member referrers only — partner conversions are settled
- * manually off the redemption counts.
+ * Grant the referrer their reward, shaped by what they actually buy — a
+ * session discount is worthless to members:
+ *
+ *   credit    active package-events pack -> +1 event credit, instantly
+ *   manual    subscription but no pack (unlimited members) -> staff comp,
+ *             fulfilled from /admin/referrals
+ *   discount  everyone else -> the reward tag + price rule
+ *
+ * Member referrers only — partner conversions are settled manually off the
+ * redemption counts.
  */
 async function grantReward(
   redemption: ReferralRedemptionRow,
@@ -61,34 +91,78 @@ async function grantReward(
   if (referrer.referrer_type !== 'member' || !referrer.momence_member_id || !referrer.email) {
     return;
   }
-
+  const memberId = referrer.momence_member_id;
   const rewardTagName = getRewardTagName();
+
+  let packs: BoughtMembership[] = [];
+  try {
+    // fresh: the 20h cache would happily report a pack that just expired.
+    packs = await fetchMemberActivePacks(memberId, { fresh: true });
+  } catch (error) {
+    log.warn(`Pack lookup failed for referrer ${referrer.id} — defaulting to discount`, error);
+  }
+  const creditPack = pickCreditPack(packs);
+  const hasSubscription = packs.some((p) => SUBSCRIPTION_TYPES.has(p.type));
+  let rewardKind: RewardKind = creditPack ? 'credit' : hasSubscription ? 'manual' : 'discount';
 
   // The unique redemption_id claim makes webhook retries no-ops. Claim before
   // the Momence write: a duplicate insert means another invocation owns this
-  // reward, tag and email included.
-  const { error } = await db.from('referral_rewards').insert({
-    referrer_id: referrer.id,
-    redemption_id: redemption.id,
-    reward_tag_name: rewardTagName,
-  });
-  if (error) {
-    if (error.code !== '23505') log.error('Reward insert failed', error);
+  // reward, delivery and email included.
+  const { data: inserted, error } = await db
+    .from('referral_rewards')
+    .insert({
+      referrer_id: referrer.id,
+      redemption_id: redemption.id,
+      reward_tag_name: rewardTagName,
+      reward_type: rewardKind,
+    })
+    .select('id')
+    .single();
+  if (error || !inserted) {
+    if (error?.code !== '23505') log.error('Reward insert failed', error);
     return;
   }
 
-  try {
-    const tagId = await getTagIdByName(rewardTagName);
-    if (tagId === null) {
-      log.error(`Reward tag "${rewardTagName}" not found — create it in the dashboard first`);
-    } else {
-      await assignMemberTag(referrer.momence_member_id, tagId);
+  if (rewardKind === 'credit' && creditPack) {
+    try {
+      const before = creditPack.eventCreditsLeft ?? 0;
+      await updateBoughtMembershipEventCredits(memberId, creditPack.id, before + 1);
+      // Delivered on the spot — nothing to consume later.
+      await db
+        .from('referral_rewards')
+        .update({
+          status: 'consumed',
+          consumed_at: new Date().toISOString(),
+          credit_bought_membership_id: creditPack.id,
+          credits_granted: 1,
+        })
+        .eq('id', inserted.id);
+    } catch (creditError) {
+      // The pack refused the top-up (expired between read and write, wrong
+      // type, API hiccup) — fall back to the tag discount so the referrer
+      // still gets something.
+      log.error(`Credit grant failed for referrer ${referrer.id} — falling back`, creditError);
+      rewardKind = 'discount';
+      await db.from('referral_rewards').update({ reward_type: 'discount' }).eq('id', inserted.id);
     }
-  } catch (tagError) {
-    // The ledger row exists either way; the admin queue surfaces grant rows
-    // whose tag never landed via the Momence member view.
-    log.error(`Reward tag assignment failed for referrer ${referrer.id}`, tagError);
   }
+
+  if (rewardKind === 'discount') {
+    try {
+      const tagId = await getTagIdByName(rewardTagName);
+      if (tagId === null) {
+        log.error(`Reward tag "${rewardTagName}" not found — create it in the dashboard first`);
+      } else {
+        await assignMemberTag(memberId, tagId);
+      }
+    } catch (tagError) {
+      // The ledger row exists either way; the admin queue surfaces grant rows
+      // whose tag never landed via the Momence member view.
+      log.error(`Reward tag assignment failed for referrer ${referrer.id}`, tagError);
+    }
+  }
+  // rewardKind === 'manual': nothing to write in Momence — the row sits
+  // 'granted' in /admin/referrals until staff fulfill it.
 
   try {
     await sendTemplate({
@@ -97,6 +171,7 @@ async function grantReward(
       props: {
         firstName: referrer.display_name,
         friendFirstName,
+        rewardKind,
         bookUrl: rewardBookUrl(),
       },
       sendKey: `referral-reward:${redemption.id}`,
@@ -108,7 +183,7 @@ async function grantReward(
   await captureEvent({
     distinctId: referrer.email,
     event: 'referral_reward_granted',
-    properties: { code: redemption.code, redemption_id: redemption.id },
+    properties: { code: redemption.code, redemption_id: redemption.id, reward_type: rewardKind },
   });
 }
 
@@ -218,6 +293,9 @@ async function consumeRewardIfDue(memberId: number, sessionBookingId: number): P
     .select('*')
     .eq('referrer_id', referrer.id)
     .eq('status', 'granted')
+    // Only tag discounts consume on the next booking; credit rewards land
+    // consumed and manual comps are fulfilled by staff.
+    .eq('reward_type', 'discount')
     .lt('granted_at', cutoff)
     .order('granted_at', { ascending: true })
     .limit(1);

--- a/apps/integrations/src/lib/referral/maintenance.ts
+++ b/apps/integrations/src/lib/referral/maintenance.ts
@@ -142,6 +142,9 @@ async function expireRewards(
     .from('referral_rewards')
     .select('*')
     .eq('status', 'granted')
+    // Only tag discounts expire on a timer; manual comps stay visible in the
+    // admin queue until staff fulfill or revoke them.
+    .eq('reward_type', 'discount')
     .lt('granted_at', cutoff)
     .order('granted_at', { ascending: true })
     .limit(BATCH);

--- a/apps/integrations/src/pages/api/admin/referrals.ts
+++ b/apps/integrations/src/pages/api/admin/referrals.ts
@@ -17,7 +17,7 @@ import {
   type ReferrerRow,
 } from '@/lib/db';
 import { findMemberByEmail, getTagIdByName, invalidateTagCache } from '@/lib/momence/host-api';
-import { revokeRedemption, revokeReward } from '@/lib/referral/admin-actions';
+import { fulfillReward, revokeRedemption, revokeReward } from '@/lib/referral/admin-actions';
 import { createPartnerReferrer, getOrCreateMemberReferrer } from '@/lib/referral/referrers';
 import { getRewardTagName, invalidateTierCache } from '@/lib/referral/registry';
 
@@ -270,6 +270,17 @@ export const POST: APIRoute = async ({ cookies, request }) => {
         if (result.outcome === 'not-found') return json({ error: 'No such reward' }, 404);
         if (result.outcome === 'not-revocable') {
           return json({ error: `Already ${result.status} — nothing to revoke` }, 409);
+        }
+        return json({ ok: true });
+      }
+
+      case 'fulfill-reward': {
+        const id = String(body.id ?? '');
+        if (!id) return json({ error: 'Missing id' }, 400);
+        const result = await fulfillReward(id, actorEmail);
+        if (result.outcome === 'not-found') return json({ error: 'No such reward' }, 404);
+        if (result.outcome === 'not-revocable') {
+          return json({ error: 'Only granted manual comps can be fulfilled' }, 409);
         }
         return json({ ok: true });
       }

--- a/apps/landing-page/src/lib/account-config.ts
+++ b/apps/landing-page/src/lib/account-config.ts
@@ -53,7 +53,7 @@ export const accountConfig = {
   referral: {
     title: 'Give 15%, Get a Discount',
     subtitle:
-      'Share your personal link. Friends get a discount on their first session — and when they book, you get a discount on your next one.',
+      'Share your personal link. Friends get a discount on their first session — and when they book, your next session gets cheaper (or free).',
     codeLabel: 'Your code',
     linkLabel: 'Your link',
     copyButton: 'Copy link',
@@ -66,7 +66,7 @@ export const accountConfig = {
       redemptionsLabel: 'Claimed',
       conversionsLabel: 'Booked',
     },
-    rewardActiveBadge: 'Reward active — discount on your next session',
+    rewardActiveBadge: 'Reward active — check your email for the details',
     errorState: 'Could not load your referral code. Please try again later.',
     disabledState: 'Your referral code is currently inactive.',
   },

--- a/apps/supabase/migrations/20260812130000_referral_reward_types.sql
+++ b/apps/supabase/migrations/20260812130000_referral_reward_types.sql
@@ -1,0 +1,20 @@
+-- Reward types for the referral program (apps/integrations). The original
+-- reward had one shape: a Momence tag whose price rule discounts the
+-- referrer's next session. That reward is worthless to exactly the best
+-- referrers -- members -- (credit-pack and subscription holders don't pay
+-- cash per session), so grants now branch on what the referrer actually buys:
+--
+--   credit    +1 event credit on their active package-events pack, via
+--             PUT /host/members/{id}/bought-memberships/{bmId}/credits.
+--             Delivered instantly, so rows land already 'consumed'.
+--   manual    subscription holders with no pack (e.g. unlimited members):
+--             a staff-fulfilled comp, 'granted' until marked consumed from
+--             /admin/referrals.
+--   discount  the original tag + price rule, for drop-in payers.
+
+alter table public.referral_rewards
+  add column reward_type text not null default 'discount'
+    check (reward_type in ('discount', 'credit', 'manual')),
+  -- Which pack was topped up and by how much (credit rewards only)
+  add column credit_bought_membership_id bigint,
+  add column credits_granted numeric;


### PR DESCRIPTION
## Problem

The referral reward was a flat next-session discount (tag + price rule) — worthless to exactly the best referrers: members. An unlimited member never pays cash per session, and a credit-pack user books with credits.

## Solution

Momence's [`updateClassCredits`](https://api.docs.momence.com/reference/apiv2hostmembersboughtmembershipscontroller_updateclasscredits) endpoint (`PUT /host/members/{memberId}/bought-memberships/{boughtMembershipId}/credits`) can top up event credits on a `package-events` bought membership. Reward grants now branch on a fresh read of the referrer's active purchases:

| Referrer has | Reward | Delivery |
|---|---|---|
| Active credit pack | **+1 free session credit** | Instant via API; ledger row lands `consumed` with pack id + amount recorded |
| Subscription, no pack (unlimited members) | **Front-desk comp** | `manual` reward, sits `granted` in /admin/referrals until staff hit "Mark fulfilled" |
| Neither (drop-in payers) | Next-session discount | The original tag + price rule, unchanged |

Details:
- The credits endpoint **sets** the count (no increment op), so we read fresh (bypassing the 20h pack cache), write `current + 1`, then invalidate the cache. A failed top-up falls back to the discount tag so the referrer still gets something.
- Reward email copy matches the delivery ("we've added a free session credit" / "your next session is on us — mention it at the front desk" / the existing discount copy).
- Expiry + next-booking-consumption sweeps now apply only to `discount` rewards; manual comps stay visible until fulfilled or revoked; credit rewards aren't one-click revocable (the credit is already delivered).
- Migration `20260812130000_referral_reward_types.sql` adds `reward_type`, `credit_bought_membership_id`, `credits_granted` to `referral_rewards`.

## Before going live

- Apply the migration.
- The credits endpoint is schema-verified but untested against the live API — worth one manual test: grant against a test member's pack and confirm the count changes in the Momence dashboard (`+1`, then set it back).

Verified with `type-check` (0 errors, both apps) and biome on all touched files.