### PR TITLE
Flat referral reward with payment-transaction consumption

### DIFF
--- a/apps/integrations/src/emails/registry.ts
+++ b/apps/integrations/src/emails/registry.ts
@@ -78,7 +78,7 @@ export const EMAIL_TEMPLATES: Registry = {
     Component: ReferralRedeemed,
   },
   'referral-reward-earned': {
-    subject: (p) => `${p.friendFirstName} booked - your Pyre reward is live`,
+    subject: (p) => `${p.friendFirstName} booked - your ${p.rewardLabel} reward is live`,
     Component: ReferralRewardEarned,
   },
 };

--- a/apps/integrations/src/emails/templates/ReferralRewardEarned.tsx
+++ b/apps/integrations/src/emails/templates/ReferralRewardEarned.tsx
@@ -3,25 +3,28 @@ import { button, EmailLayout, heading, text } from '../components/EmailLayout';
 import type { ReferralRewardEarnedProps } from '../types';
 
 // To the referrer when a friend they referred completes their first booking:
-// their thank-you discount is live for their next session.
+// their reward — a fixed amount off their next purchase, applied by the
+// reward tag's price rule — is live.
 
 export function ReferralRewardEarned({
   firstName,
   friendFirstName,
+  rewardLabel,
   bookUrl,
 }: ReferralRewardEarnedProps) {
   return (
-    <EmailLayout preview="Your referral reward at Pyre is live" background="trees">
+    <EmailLayout preview={`Your ${rewardLabel} reward at Pyre is live`} background="trees">
       <Text style={heading}>Nice one, {firstName}</Text>
       <Text style={text}>
-        {friendFirstName} just booked their first session at Pyre — thanks to you. As a thank-you, a
-        discount on your next session is now live on your account.
+        {friendFirstName} just booked their first session at Pyre — thanks to you. As a thank-you,
+        {` ${rewardLabel}`} off your next purchase is now live on your account.
       </Text>
       <Text style={text}>
-        Book with this email address and it comes off automatically at checkout. No code needed.
+        It comes off automatically at checkout — sessions, credit packs, or memberships. No code
+        needed, just use this email address.
       </Text>
       <Button href={bookUrl} style={button}>
-        Book your next session
+        Use your reward
       </Button>
       <Text style={text}>Keep them coming. Wes + Julien</Text>
     </EmailLayout>
@@ -31,6 +34,7 @@ export function ReferralRewardEarned({
 ReferralRewardEarned.PreviewProps = {
   firstName: 'Wes',
   friendFirstName: 'Jane',
+  rewardLabel: '$15',
   bookUrl: 'https://pyresauna.com/events?utm_source=referral-reward&utm_medium=referral',
 } satisfies ReferralRewardEarnedProps;
 

--- a/apps/integrations/src/emails/types.ts
+++ b/apps/integrations/src/emails/types.ts
@@ -119,6 +119,8 @@ export interface ReferralRedeemedProps {
 export interface ReferralRewardEarnedProps {
   firstName: string;
   friendFirstName: string;
+  /** The reward as copy, e.g. "$15" (REFERRAL_REWARD_LABEL). */
+  rewardLabel: string;
   bookUrl: string;
 }
 

--- a/apps/integrations/src/lib/db.ts
+++ b/apps/integrations/src/lib/db.ts
@@ -142,6 +142,8 @@ export interface ReferralRewardRow {
   granted_at: string;
   consumed_at: string | null;
   consumed_session_booking_id: number | null;
+  /** The payment transaction where the reward price rule fired. */
+  consumed_payment_transaction_id: number | null;
   reward_tag_removed_at: string | null;
   decided_by: string | null;
   created_at: string;

--- a/apps/integrations/src/lib/momence/host-api.ts
+++ b/apps/integrations/src/lib/momence/host-api.ts
@@ -285,6 +285,55 @@ export async function fetchSales(
   return data.payload ?? [];
 }
 
+// --- Payment transactions (the consumption signal for referral rewards) ---
+
+export interface PaymentTransactionDiscount {
+  id: number;
+  discountCodeId: number | null;
+  /** Set when a dashboard Price Rule produced the discount. */
+  priceRuleId: number | null;
+}
+
+export interface PaymentTransactionSaleItem {
+  id: number;
+  saleItemId: number;
+  itemType: SaleItemType;
+  itemName: string;
+  discountCode: PaymentTransactionDiscount | null;
+}
+
+export interface PaymentTransactionSale {
+  id: number;
+  saleDate: string;
+  items: PaymentTransactionSaleItem[];
+}
+
+export interface PaymentTransaction {
+  id: number;
+  payingMember: SaleMember | null;
+  paymentStatus: 'succeeded' | 'failed' | 'pending' | 'voided' | 'unpaid' | 'incomplete';
+  /** Where the charge came from — renewals arrive as scheduled/auto sources. */
+  paymentSource: string;
+  purchaseType: string;
+  paidInCurrency: string;
+  sales?: PaymentTransactionSale[];
+  createdAt: string;
+}
+
+/**
+ * Full detail for one payment transaction — the payment-transaction-succeeded
+ * webhook only carries the id, so handlers fetch the rest here. Includes which
+ * Price Rule (if any) discounted each sale item.
+ */
+export async function fetchPaymentTransaction(
+  paymentTransactionId: number
+): Promise<PaymentTransaction> {
+  return momenceRequest<PaymentTransaction>(
+    'GET',
+    `/host/payment-transactions/${paymentTransactionId}`
+  );
+}
+
 // --- Tags (name -> id map, plus write-back so staff see journey status) ---
 
 export interface HostTag {

--- a/apps/integrations/src/lib/referral/conversion.ts
+++ b/apps/integrations/src/lib/referral/conversion.ts
@@ -8,20 +8,25 @@ import { createWebhookLogger } from '@pyre/webhook-core';
 import { captureEvent } from '@/lib/analytics/posthog';
 import { getDb, type ReferralRedemptionRow, type ReferrerRow } from '@/lib/db';
 import { sendTemplate } from '@/lib/email/send';
-import { assignMemberTag, getTagIdByName, removeMemberTag } from '@/lib/momence/host-api';
+import {
+  assignMemberTag,
+  fetchPaymentTransaction,
+  getTagIdByName,
+  type PaymentTransaction,
+  removeMemberTag,
+} from '@/lib/momence/host-api';
 import { isMemberFirstBooking } from '@/lib/webhooks/momence';
-import { getReferrer, getReferrerByMemberId, getRewardTagName } from './registry';
+import {
+  getReferrer,
+  getReferrerByMemberId,
+  getRewardLabel,
+  getRewardPriceRuleId,
+  getRewardTagName,
+} from './registry';
 
 const log = createWebhookLogger('Referral Conversion');
 
 const TABLE = 'referral_redemptions';
-
-/**
- * The conversion-granting booking must not also consume the reward it just
- * granted when webhooks arrive out of order — a reward is only consumable
- * this long after it was granted.
- */
-const REWARD_GRACE_MS = 5 * 60 * 1000;
 
 function rewardBookUrl(): string {
   const site =
@@ -97,6 +102,7 @@ async function grantReward(
       props: {
         firstName: referrer.display_name,
         friendFirstName,
+        rewardLabel: getRewardLabel(),
         bookUrl: rewardBookUrl(),
       },
       sendKey: `referral-reward:${redemption.id}`,
@@ -199,67 +205,120 @@ async function revokeNotFirstTime(redemption: ReferralRedemptionRow): Promise<vo
   });
 }
 
-/**
- * The referrer's next booking after a reward grant consumes the reward:
- * remove the reward tag, mark the ledger row. Known v1 approximation — the
- * booking may not have actually used the discount (credit/membership
- * bookings); sales-price inspection is the v2 upgrade.
- */
-async function consumeRewardIfDue(memberId: number, sessionBookingId: number): Promise<void> {
-  const db = getDb();
-  if (!db) return;
+// Charges from these sources are renewals/system jobs — a Price Rule firing
+// there (or a stale-looking discount entry) must not spend the reward.
+const RENEWAL_SOURCES = new Set([
+  'auto-renew-package-membership',
+  'scheduled-job-renew-membership',
+  'scheduled-job-retry-failed-membership-charge',
+  'scheduled-job-payment-plan',
+  'scheduled-job-process-unpaid-transaction',
+  'scheduled-job-pay-for-membership',
+  'scheduled-job-charge-tuition-installments',
+]);
 
-  const referrer = await getReferrerByMemberId(memberId);
-  if (!referrer) return;
-
-  const cutoff = new Date(Date.now() - REWARD_GRACE_MS).toISOString();
-  const { data } = await db
-    .from('referral_rewards')
-    .select('*')
-    .eq('referrer_id', referrer.id)
-    .eq('status', 'granted')
-    .lt('granted_at', cutoff)
-    .order('granted_at', { ascending: true })
-    .limit(1);
-  const reward = data?.[0];
-  if (!reward) return;
-
-  let tagRemoved = false;
-  try {
-    const tagId = await getTagIdByName(reward.reward_tag_name);
-    if (tagId !== null && referrer.momence_member_id) {
-      await removeMemberTag(referrer.momence_member_id, tagId);
-      tagRemoved = true;
+/** Every Price Rule id that discounted an item on this transaction. */
+function appliedPriceRuleIds(transaction: PaymentTransaction): number[] {
+  const ids: number[] = [];
+  for (const sale of transaction.sales ?? []) {
+    for (const item of sale.items ?? []) {
+      if (item.discountCode?.priceRuleId != null) ids.push(item.discountCode.priceRuleId);
     }
-  } catch (error) {
-    log.warn(`Reward tag removal failed for referrer ${referrer.id}`, error);
   }
-
-  const { data: updated } = await db
-    .from('referral_rewards')
-    .update({
-      status: 'consumed',
-      consumed_at: new Date().toISOString(),
-      consumed_session_booking_id: sessionBookingId,
-      ...(tagRemoved && { reward_tag_removed_at: new Date().toISOString() }),
-    })
-    .eq('id', reward.id)
-    .eq('status', 'granted')
-    .select('id');
-  if (!updated || updated.length === 0) return;
-
-  await captureEvent({
-    distinctId: referrer.email ?? referrer.code,
-    event: 'referral_reward_consumed',
-    properties: { code: referrer.code, session_booking_id: sessionBookingId },
-  });
+  return ids;
 }
 
 /**
- * session-booked hook. Two independent questions about the person who just
- * booked: are they a referred friend awaiting their first booking (convert +
- * reward the referrer), and are they a referrer holding an unconsumed reward
- * (consume it)?
+ * payment-transaction-succeeded hook: if the payer is a referrer holding an
+ * unconsumed reward and the reward's Price Rule actually fired on this
+ * transaction, the reward is spent — remove the tag, close the ledger row.
+ *
+ * With REFERRAL_REWARD_PRICE_RULE_ID set the match is exact (other rules,
+ * like the partner discount, firing on the same member never consume the
+ * reward). Without it, any Price Rule discount on a non-renewal charge
+ * counts — good enough until the rule id is captured from a test purchase.
+ */
+export async function handleReferralPaymentTransaction(
+  paymentTransactionId: number
+): Promise<void> {
+  const db = getDb();
+  if (!db) return;
+
+  try {
+    let transaction: PaymentTransaction;
+    try {
+      transaction = await fetchPaymentTransaction(paymentTransactionId);
+    } catch (error) {
+      log.warn(`Payment transaction ${paymentTransactionId} fetch failed`, error);
+      return;
+    }
+
+    if (transaction.paymentStatus !== 'succeeded') return;
+    if (!transaction.payingMember?.id) return;
+    if (RENEWAL_SOURCES.has(transaction.paymentSource)) return;
+
+    const referrer = await getReferrerByMemberId(transaction.payingMember.id);
+    if (!referrer) return;
+
+    const { data } = await db
+      .from('referral_rewards')
+      .select('*')
+      .eq('referrer_id', referrer.id)
+      .eq('status', 'granted')
+      .order('granted_at', { ascending: true })
+      .limit(1);
+    const reward = data?.[0];
+    if (!reward) return;
+
+    const ruleIds = appliedPriceRuleIds(transaction);
+    const expectedRuleId = getRewardPriceRuleId();
+    const rewardRuleFired =
+      expectedRuleId !== null ? ruleIds.includes(expectedRuleId) : ruleIds.length > 0;
+    if (!rewardRuleFired) return;
+
+    let tagRemoved = false;
+    try {
+      const tagId = await getTagIdByName(reward.reward_tag_name);
+      if (tagId !== null && referrer.momence_member_id) {
+        await removeMemberTag(referrer.momence_member_id, tagId);
+        tagRemoved = true;
+      }
+    } catch (error) {
+      log.warn(`Reward tag removal failed for referrer ${referrer.id}`, error);
+    }
+
+    const { data: updated } = await db
+      .from('referral_rewards')
+      .update({
+        status: 'consumed',
+        consumed_at: new Date().toISOString(),
+        consumed_payment_transaction_id: transaction.id,
+        ...(tagRemoved && { reward_tag_removed_at: new Date().toISOString() }),
+      })
+      .eq('id', reward.id)
+      .eq('status', 'granted')
+      .select('id');
+    if (!updated || updated.length === 0) return;
+
+    await captureEvent({
+      distinctId: referrer.email ?? referrer.code,
+      event: 'referral_reward_consumed',
+      properties: {
+        code: referrer.code,
+        payment_transaction_id: transaction.id,
+        purchase_type: transaction.purchaseType,
+        rule_matched: expectedRuleId !== null,
+      },
+    });
+  } catch (error) {
+    log.error('Referral payment-transaction handling failed', error);
+  }
+}
+
+/**
+ * session-booked hook: is the person who just booked a referred friend
+ * awaiting their first booking? Convert the redemption and reward the
+ * referrer if so.
  */
 export async function handleReferralBooking(params: {
   sessionId: number;
@@ -321,11 +380,9 @@ export async function handleReferralBooking(params: {
     log.error('Referral conversion handling failed', error);
   }
 
-  try {
-    await consumeRewardIfDue(params.targetMemberId, params.sessionBookingId);
-  } catch (error) {
-    log.error('Reward consumption handling failed', error);
-  }
+  // Reward consumption is driven by payment-transaction-succeeded (the
+  // transaction records whether the reward's Price Rule actually fired) —
+  // a plain booking must not eat the reward.
 }
 
 /**

--- a/apps/integrations/src/lib/referral/registry.ts
+++ b/apps/integrations/src/lib/referral/registry.ts
@@ -117,6 +117,24 @@ export function getRewardTagName(): string {
   );
 }
 
+/**
+ * The Momence Price Rule id behind the reward tag's discount. Transactions
+ * record which rule produced each discount, so with this set, consumption is
+ * exact: the reward is spent only when THIS rule fires. Rules have no list
+ * API — capture the id from a test transaction after creating the rule.
+ */
+export function getRewardPriceRuleId(): number | null {
+  const raw =
+    import.meta.env.REFERRAL_REWARD_PRICE_RULE_ID ?? process.env.REFERRAL_REWARD_PRICE_RULE_ID;
+  const parsed = Number.parseInt(raw ?? '', 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/** How the reward reads in email/UI copy, e.g. "$15". */
+export function getRewardLabel(): string {
+  return import.meta.env.REFERRAL_REWARD_LABEL ?? process.env.REFERRAL_REWARD_LABEL ?? '$15';
+}
+
 /** How long a redeemed-but-unbooked discount lives before the sweep expires it. */
 export function getRedemptionExpiryDays(): number {
   const raw = import.meta.env.REFERRAL_EXPIRY_DAYS ?? process.env.REFERRAL_EXPIRY_DAYS;

--- a/apps/integrations/src/lib/webhooks/momence.ts
+++ b/apps/integrations/src/lib/webhooks/momence.ts
@@ -30,7 +30,8 @@ export type MomenceEventType =
   | 'member-address-updated'
   | 'member-address-deleted'
   | 'session-booked'
-  | 'session-booking-cancelled';
+  | 'session-booking-cancelled'
+  | 'payment-transaction-succeeded';
 
 export interface MomenceWebhookResult<T = unknown> {
   event: string;

--- a/apps/integrations/src/pages/api/webhooks/momence.ts
+++ b/apps/integrations/src/pages/api/webhooks/momence.ts
@@ -10,7 +10,11 @@ import { trackBookingEvent } from '@/lib/analytics/track-booking';
 import { upsertResendContact } from '@/lib/email/audience';
 import { sendBookingConfirmationEmails } from '@/lib/email/triggers/booking-confirmation';
 import { resolveSession } from '@/lib/momence-events';
-import { handleReferralBooking, handleReferralCancellation } from '@/lib/referral/conversion';
+import {
+  handleReferralBooking,
+  handleReferralCancellation,
+  handleReferralPaymentTransaction,
+} from '@/lib/referral/conversion';
 import { dispatchTrigger } from '@/lib/triggers/dispatch';
 import { instrumentWebhook, type TracedAPIRoute } from '@/lib/webhooks/instrument';
 import {
@@ -33,6 +37,10 @@ const ADDRESS_EVENTS: MomenceEventType[] = [
   'member-address-deleted',
 ];
 const BOOKING_EVENTS: MomenceEventType[] = ['session-booked', 'session-booking-cancelled'];
+
+interface MomencePaymentTransactionPayload {
+  id: number;
+}
 
 interface MomenceBookingPayload {
   sessionId: number;
@@ -233,6 +241,17 @@ const handler: TracedAPIRoute = async ({ request }, tracer) => {
       await handleAddressEvent(event as MomenceEventType, payload as MomenceAddressPayload, tracer);
     } else if (BOOKING_EVENTS.includes(event as MomenceEventType)) {
       await handleBookingEvent(event as MomenceEventType, payload as MomenceBookingPayload, tracer);
+    } else if (event === 'payment-transaction-succeeded') {
+      // Referral reward consumption. The payload is just the transaction id;
+      // the handler fetches the detail and catches its own errors.
+      const transactionId = (payload as MomencePaymentTransactionPayload)?.id;
+      if (typeof transactionId === 'number') {
+        await tracer.span(
+          'Handle referral payment transaction',
+          () => handleReferralPaymentTransaction(transactionId),
+          { transactionId }
+        );
+      }
     } else {
       log.info(`Ignoring unhandled event: ${event}`);
     }

--- a/apps/landing-page/src/lib/account-config.ts
+++ b/apps/landing-page/src/lib/account-config.ts
@@ -53,7 +53,7 @@ export const accountConfig = {
   referral: {
     title: 'Give 15%, Get a Discount',
     subtitle:
-      'Share your personal link. Friends get a discount on their first session — and when they book, you get a discount on your next one.',
+      'Share your personal link. Friends get a discount on their first session — and when they book, you get $15 off your next purchase.',
     codeLabel: 'Your code',
     linkLabel: 'Your link',
     copyButton: 'Copy link',
@@ -66,7 +66,7 @@ export const accountConfig = {
       redemptionsLabel: 'Claimed',
       conversionsLabel: 'Booked',
     },
-    rewardActiveBadge: 'Reward active — discount on your next session',
+    rewardActiveBadge: 'Reward active — $15 off your next purchase',
     errorState: 'Could not load your referral code. Please try again later.',
     disabledState: 'Your referral code is currently inactive.',
   },

--- a/apps/supabase/migrations/20260812150000_referral_reward_transactions.sql
+++ b/apps/supabase/migrations/20260812150000_referral_reward_transactions.sql
@@ -1,0 +1,7 @@
+-- Referral reward consumption moves from "the referrer's next session
+-- booking" to "the payment transaction where the reward price rule actually
+-- fired" (payment-transaction-succeeded webhook + GET
+-- /host/payment-transactions/{id}, which records the priceRuleId behind every
+-- discount). Record which transaction consumed the reward.
+alter table public.referral_rewards
+  add column consumed_payment_transaction_id bigint;


### PR DESCRIPTION
## What changed

Supersedes #151 with the simpler, flat model: **every referrer gets the same reward** — the `referral-reward` tag plus a fixed-amount ($15) Price Rule, scoped in the Momence dashboard to sessions, credit packs, and memberships. No credit-grant branching.

**Consumption is now exact and real-time.** The old model removed the reward tag on the referrer's next session *booking* — wrong once the rule covers pack/membership purchases (no booking webhook fires) and wrong when a booking doesn't use the discount. Now:

- Momence's `payment-transaction-succeeded` webhook (payload: `{id}`) hits the existing webhook route.
- The handler fetches `GET /host/payment-transactions/{id}`, which records the **`priceRuleId` behind every discount** plus `paymentSource` and the paying member.
- The reward is consumed only when the payer is a referrer holding a granted reward **and the reward's Price Rule actually fired** on that transaction. Renewals (`auto-renew-package-membership`, `scheduled-job-*`) and other rules firing (e.g. the partner 15%) can never consume it.
- `REFERRAL_REWARD_PRICE_RULE_ID` pins the exact rule id; unset, any Price-Rule discount on a non-renewal charge counts (interim heuristic).
- `REFERRAL_REWARD_LABEL` (default `$15`) drives the email/UI copy.

Migration `20260812150000_referral_reward_transactions.sql` adds `consumed_payment_transaction_id` to the ledger.

## Setup on merge

1. In Momence: change the `referral-reward` Price Rule to a **$15 absolute discount** scoped to sessions + credit packs + memberships.
2. In Momence webhook settings: subscribe **payment-transaction-succeeded** to the existing webhook URL.
3. Apply the migration.
4. Make a test purchase with a tagged test member, read the rule id off the transaction (`/host/payment-transactions/{id}`), set `REFERRAL_REWARD_PRICE_RULE_ID` on pyre-integrations, redeploy.

Verified with type-check (0 errors, both apps) and biome.